### PR TITLE
Minor build fixes

### DIFF
--- a/dsr_bringup2/package.xml
+++ b/dsr_bringup2/package.xml
@@ -5,7 +5,7 @@
   <version>1.1.0</version>
   <description>dsr_bringup2 package</description>
 
-  <author email="minsoo.song@doosan.com">Minsoo Song</author>   
+  <author email="minsoo.song@doosan.com">Minsoo Song</author>
 
   <maintainer email="minsoo.song@doosan.com">Minsoo Song</maintainer>
   <maintainer email="ros.robotics@doosan.com">Doosan Robotics</maintainer>
@@ -13,13 +13,13 @@
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/doosan_robotics</url>
 
-  <!--<buildtool_depend>ament_python</buildtool_depend>-->
-
 
   <!--build_depend>roslaunch</build_depend-->
   <build_depend>gazebo_ros</build_depend>
-  <!--??? exec_depend>gazebo_ros</run_depend-->
-  <!--??? exec_depend>rviz</run_depend-->
+  <!--???
+  exec_depend>gazebo_ros</run_depend-->
+  <!--???
+  exec_depend>rviz</run_depend-->
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>dsr_msgs2</exec_depend>

--- a/dsr_bringup2/package.xml
+++ b/dsr_bringup2/package.xml
@@ -13,7 +13,7 @@
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/doosan_robotics</url>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <!--<buildtool_depend>ament_python</buildtool_depend>-->
 
 
   <!--build_depend>roslaunch</build_depend-->

--- a/dsr_gazebo2/package.xml
+++ b/dsr_gazebo2/package.xml
@@ -21,6 +21,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>control_msgs</exec_depend>
+  <exec_depend>gazebo_ros_pkgs</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>hardware_interface</exec_depend>

--- a/dsr_moveit2/h2017_moveit_config/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/h2017_moveit_config/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>


### PR DESCRIPTION
Fixes the following issues:

- buildtool_depend ament_python causes rosdep error: https://github.com/ros2/ros2_documentation/issues/508
- Add rosdep dependency for gazebo_ros_pkgs
- Add xacro.load_yaml as load_yaml is deprecated

Other issues / features not included:

- Robot_state_publisher remappings causes TF to not find transforms for the robot. I fixed this by adding a second robot_state_publisher without remappings. This should be investigated.
- Not all the links have collision elements. This should be fixed.
- In the start.launch.py files for the moveit pacakges, it would make it a lot more flexible if you could add the robot_description and robot_description_semantic as optional arguments 