### PR TITLE
Fixes spawn_on_gazebo & visualservoing

### DIFF
--- a/dsr_bringup2/launch/dsr_bringup2_spawn_on_gazebo.launch.py
+++ b/dsr_bringup2/launch/dsr_bringup2_spawn_on_gazebo.launch.py
@@ -192,6 +192,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(included_launch_file_path),
         launch_arguments={'use_gazebo': LaunchConfiguration('gz'), 
                           'name' : LaunchConfiguration('name'),
+                          'color' : LaunchConfiguration('color'),
                           'x' :LaunchConfiguration('x'),
                           'y' :LaunchConfiguration('y'),
                           'z' :LaunchConfiguration('z'),

--- a/dsr_gazebo2/launch/dsr_spawn_on_gazebo.launch.py
+++ b/dsr_gazebo2/launch/dsr_spawn_on_gazebo.launch.py
@@ -84,6 +84,9 @@ def generate_launch_description():
             " ",
             "use_gazebo:=",
             LaunchConfiguration('use_gazebo'),
+            " ", 
+            "color:=", 
+            LaunchConfiguration('color'),
             " ",
             "namespace:=",
             PathJoinSubstitution([LaunchConfiguration('name'), "gz"])


### PR DESCRIPTION
Enable color change function of second robot (gazebo), add '__init__.py' to example of visual servoing.