### PR TITLE
Fixes get_current_posx issue in python api wrapper

### DIFF
--- a/common2/imp/DSR_ROBOT2.py
+++ b/common2/imp/DSR_ROBOT2.py
@@ -954,10 +954,9 @@ def get_current_posx(ref=None):
                 pos = []
                 for i in range(POINT_COUNT):
                     pos.append(posx_info[0][i])
-                    sol = int(round( posx_info[0][6] ))
-                    conv_posx = posx(pos)
-
-                    return conv_posx, sol
+                sol = int(round( posx_info[0][6] ))
+                conv_posx = posx(pos)
+                return conv_posx, sol
     return 0
 
 def get_current_tool_flange_posx(ref=None):


### PR DESCRIPTION
### Description:

get_current_posx service over cli works well.
![image](https://github.com/user-attachments/assets/1b884244-dbfc-42b5-b867-df2011220e32)

but get_current_posx api over python wrapper doesn't work.
```python3
pos, sol = get_current_posx()

print(pos)   
# expected : [32.18661117553711, 630.8297729492188, 247.25726318359375, 95.68321228027344, 93.64844512939453, 133.8678436279297] like cli response.
# real : [32.18661117553711, 0,0,0,0,0]
```

