### PR TITLE
Update remove just sleep and add polling to check drcf loaded

### DIFF
--- a/dsr_hardware2/src/dsr_hw_interface2.cpp
+++ b/dsr_hardware2/src/dsr_hw_interface2.cpp
@@ -129,8 +129,6 @@ CallbackReturn DRHWInterface::on_init(const hardware_interface::HardwareInfo & i
     {
         return CallbackReturn::ERROR;
     }
-    // TODO(leeminju531) Workaround sleep. replace with the event come out from drcf.
-    sleep(8);
 
     // robot has 6 joints and 2 interfaces
     joint_position_.assign(6, 0);
@@ -204,12 +202,46 @@ CallbackReturn DRHWInterface::on_init(const hardware_interface::HardwareInfo & i
     {
         usleep(nDelay);
     }
-
-    if(!Drfl.open_connection(m_host, m_port))
+    
+    // Try to connect to DRCF for 15 (30 * 0.5) sec.
+    const size_t max_tries = 30;
+    bool is_connected = false;
+    for (size_t retry = 0; retry < max_tries; ++retry) {
+        is_connected = Drfl.open_connection(m_host, m_port);
+        if(!is_connected) {
+            RCLCPP_INFO(rclcpp::get_logger("dsr_hw_interface2"),"Connecting failure.. retry...");
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            continue;
+        }
+        RCLCPP_INFO(rclcpp::get_logger("dsr_hw_interface2"),"Connected to DRCF");
+        break;
+    }
+    if(!is_connected)
     {
         RCLCPP_ERROR(rclcpp::get_logger("dsr_hw_interface2"),"    DSRInterface::init() DRCF connecting ERROR!!!");
         return CallbackReturn::ERROR;
     }
+    // Check whether DRCF loaded successfully for 10 sec..
+    // Even thought, the server connected,
+    // The drcf could still be in the booting process. 
+    // Need to make sure it loaded successfully.
+    // I assumed the monitoring is alive due to the server totally booted-up.
+    static bool isLoaded = false;
+    Drfl.set_on_monitoring_data([](const LPMONITORING_DATA /*pData*/) {
+        RCLCPP_ERROR(rclcpp::get_logger("dsr_hw_interface2"),"SUCCESFFULY LOADDED");
+        isLoaded = true;
+    });
+    for (size_t retry = 0; retry < 100; ++retry) {
+        if(isLoaded)    break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    if(!isLoaded)
+    {
+        RCLCPP_ERROR(rclcpp::get_logger("dsr_hw_interface2"),"DRCF Connected, but not successfully loaded !!!");
+        return CallbackReturn::ERROR;
+    }
+    Drfl.set_on_monitoring_data(DSRInterface::OnMonitoringDataCB); // in order to unset upper callback.
+
     RCLCPP_INFO(rclcpp::get_logger("dsr_hw_interface2"),"_______________________________________________\n"); 
     RCLCPP_INFO(rclcpp::get_logger("dsr_hw_interface2"),"    OPEN CONNECTION");
     RCLCPP_INFO(rclcpp::get_logger("dsr_hw_interface2"),"_______________________________________________\n");   


### PR DESCRIPTION
### Problem
In hw_interface, we added a sleep as a workaround to ensure the server is fully loaded.
However, this introduces two side effects:

(a) Unnecessary wait: Even if the server is already loaded, the system still waits for the sleep time.
(b) Potential failure due to resource limitations: In cases of limited resources, users may experience failures if the sleep time is exceeded. (related to https://github.com/doosan-robotics/doosan-robot2/issues/142#issuecomment-2570083397)

### Proposed Solutions. 
1. Use a polling pattern with minimal sleep: This will help address issue (a), as the connection will be attempted at regular intervals with shorter wait times, avoiding unnecessary delays.
2. IExtend the total timeout (from 8 seconds to 30 seconds): This will address issue (b) by providing enough time for the server to load and ensuring that minor performance delays don’t cause failures.