### PR TITLE
Fixes move_stop blocking bug while moving

### DIFF
--- a/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
+++ b/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
@@ -526,6 +526,9 @@ protected:
   std::vector<std::string> command_interface_types_;
   std::vector<std::string> state_interface_types_;
 
+  // We may need to distinguish the callback group based on the traits of the services.
+  rclcpp::CallbackGroup::SharedPtr cb_group_;
+
   rclcpp::Subscription<dsr_msgs2::msg::JogMultiAxis>::SharedPtr        m_sub_jog_multi_axis;
   rclcpp::Subscription<dsr_msgs2::msg::AlterMotionStream>::SharedPtr   m_sub_alter_motion_stream;
   rclcpp::Subscription<dsr_msgs2::msg::ServojStream>::SharedPtr        m_sub_servoj_stream;

--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -1907,6 +1907,7 @@ auto torque_rt_cb = [this](const std::shared_ptr<dsr_msgs2::msg::TorqueRtStream>
 
     Drfl->torque_rt(tor.data(), time);
 };
+  cb_group_ = get_node()->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   // Subscription declarations
   m_sub_jog_multi_axis                = get_node()->create_subscription<dsr_msgs2::msg::JogMultiAxis>("jog_multi", 10, jog_multi_axis_cb);
@@ -1951,7 +1952,7 @@ auto torque_rt_cb = [this](const std::shared_ptr<dsr_msgs2::msg::TorqueRtStream>
   m_nh_srv_jog                        = get_node()->create_service<dsr_msgs2::srv::Jog>("motion/jog", jog_cb);              
   m_nh_srv_jog_multi                  = get_node()->create_service<dsr_msgs2::srv::JogMulti>("motion/jog_multi", jog_multi_cb);                      
   m_nh_srv_move_pause                 = get_node()->create_service<dsr_msgs2::srv::MovePause>("motion/move_pause", move_pause_cb);                      
-  m_nh_srv_move_stop                  = get_node()->create_service<dsr_msgs2::srv::MoveStop>("motion/move_stop", move_stop_cb);                  
+  m_nh_srv_move_stop                  = get_node()->create_service<dsr_msgs2::srv::MoveStop>("motion/move_stop", move_stop_cb, rmw_qos_profile_services_default, cb_group_);
   m_nh_srv_move_resume                = get_node()->create_service<dsr_msgs2::srv::MoveResume>("motion/move_resume", move_resume_cb);                  
   m_nh_srv_trans                      = get_node()->create_service<dsr_msgs2::srv::Trans>("motion/trans", trans_cb);                  
   m_nh_srv_fkin                       = get_node()->create_service<dsr_msgs2::srv::Fkin>("motion/fkin", fkin_cb);              


### PR DESCRIPTION
Related Issue : https://github.com/doosan-robotics/doosan-robot2/issues/82#issuecomment-2630844457 

Currently, calling the `move_stop` service while the robot is moving doesn't work because all services are in the same callback group.

In this PR, I've separated the `move_stop` service from the other services.

In the future, we might need to categorize services based on their traits and assign each to a separate callback group.