### PR TITLE
Update emulator script and termination command

### DIFF
--- a/common2/bin/run_drcf.sh
+++ b/common2/bin/run_drcf.sh
@@ -27,13 +27,15 @@ fi
 echo "run : '$container_name' ..."
 
 
+
 # check 
 if [ "$(docker ps -q -f name=$container_name)" ]; then
-    echo "The emulator '$container_name' is already running."
-else
-    # run
-    docker run -dit --rm --name $container_name --env ROBOT_MODEL=${2^^} -p $server_port:12345 $emulator_image
+    echo "The emulator '$container_name' is already running... kill it"
+    docker ps -a --filter name=emulator -q | xargs -r docker rm -f
 fi
+# run
+docker run -dit --rm --name $container_name --env ROBOT_MODEL=${2^^} -p $server_port:12345 $emulator_image
+
 
 if [ `getconf LONG_BIT` = "64" ]
 then

--- a/dsr_bringup2/dsr_bringup2/run_emulator.py
+++ b/dsr_bringup2/dsr_bringup2/run_emulator.py
@@ -60,7 +60,7 @@ class VirtualDRCF(Node):
         os.system(start_cmd)
 
     def terminate_drcf(self):
-        stop_cmd = "docker ps -a --filter name={} -q | xargs -r docker stop".\
+        stop_cmd = "docker ps -a --filter name={} -q | xargs -r docker rm -f".\
             format(self.emulator_name)
         print("stop_cmd : ",stop_cmd)
         os.system(stop_cmd)


### PR DESCRIPTION
### Descriptions 

1. When terminating the emulator node, it’s currently using` docker stop `to stop the emulator. I’ve suggested using `docker rm -f `because it's at least five times faster. This change improves the speed of the termination process.

2. When restarting with virtual mode, sometimes it reports “emulator is already running” from `drcf_run.sh`, and ignores the command to start the emulator. This issue occurs because of delays from previous termination processes. As a result, even though the robot is spawned successfully, none of the services work due to the emulator not being running.
The fix: ensure the emulator is correctly spawned within `drcf_run.sh.`