### PR TITLE
Use xacro.load_yaml syntax to remove warnings (#179)

### DIFF
--- a/dsr_description2/urdf/h2017.urdf
+++ b/dsr_description2/urdf/h2017.urdf
@@ -22,6 +22,7 @@
 					</geometry>
 				</visual>
 			</link>
+		<link name="base"/>
 		<joint name="base_link-base" type="fixed">
 			<origin rpy="0 0 0" xyz="0 0 0.450"/>
 			<parent link="base_link"/>

--- a/dsr_moveit2/dsr_moveit_config_a0509/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_a0509/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_a0912/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_a0912/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_e0509/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_e0509/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_h2515/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_h2515/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_m0609/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_m0609/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_m0617/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_m0617/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_m1013/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_m1013/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_m1509/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_m1509/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>

--- a/dsr_moveit2/dsr_moveit_config_p3020/config/dsr.ros2_control.xacro
+++ b/dsr_moveit2/dsr_moveit_config_p3020/config/dsr.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="dsr_moveit_ros2_control" params="name initial_positions_file">
-        <xacro:property name="initial_positions" value="${load_yaml(initial_positions_file)['initial_positions']}"/>
+        <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${name}" type="system">
             <hardware>


### PR DESCRIPTION
* Use xacro.load_yaml to remove warnings
* Fix missing base link in h2017.urdf