### PR TITLE
Remove all tool0 links in urdf

### DIFF
--- a/dsr_description2/urdf/a0509.urdf
+++ b/dsr_description2/urdf/a0509.urdf
@@ -288,10 +288,10 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+		<!-- <link name="tool0"/>
 		<joint name="joint_6-tool0" type="fixed">
 			<origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
 			<parent link="link_6"/>
 			<child link="tool0"/>
-		</joint>
+		</joint> -->
 </robot>

--- a/dsr_description2/urdf/a0912.urdf
+++ b/dsr_description2/urdf/a0912.urdf
@@ -290,10 +290,10 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+		<!-- <link name="tool0"/>
 		<joint name="joint_6-tool0" type="fixed">
 			<origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
 			<parent link="link_6"/>
 			<child link="tool0"/>
-		</joint>
+		</joint> -->
 </robot>

--- a/dsr_description2/urdf/e0509.urdf
+++ b/dsr_description2/urdf/e0509.urdf
@@ -278,10 +278,10 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+		<!-- <link name="tool0"/>
 		<joint name="joint_6-tool0" type="fixed">
 			<origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
 			<parent link="link_6"/>
 			<child link="tool0"/>
-		</joint>
+		</joint> -->
 </robot>

--- a/dsr_description2/urdf/h2017.urdf
+++ b/dsr_description2/urdf/h2017.urdf
@@ -241,10 +241,10 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+		<!-- <link name="tool0"/>
 		<joint name="joint_6-tool0" type="fixed">
 			<origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
 			<parent link="link_6"/>
 			<child link="tool0"/>
-		</joint>
+		</joint> -->
 </robot>

--- a/dsr_description2/urdf/h2515.urdf
+++ b/dsr_description2/urdf/h2515.urdf
@@ -241,10 +241,10 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+		<!-- <link name="tool0"/>
 		<joint name="joint_6-tool0" type="fixed">
 			<origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
 			<parent link="link_6"/>
 			<child link="tool0"/>
-		</joint>
+		</joint> -->
 </robot>

--- a/dsr_description2/urdf/m0609.urdf
+++ b/dsr_description2/urdf/m0609.urdf
@@ -244,12 +244,12 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+		<!-- <link name="tool0"/>
 		<joint name="joint_6-tool0" type="fixed">
 			<origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
 			<parent link="link_6"/>
 			<child link="tool0"/>
-		</joint>
+		</joint> -->
 
 
 </robot>

--- a/dsr_description2/urdf/m0617.urdf
+++ b/dsr_description2/urdf/m0617.urdf
@@ -241,10 +241,10 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+		<!-- <link name="tool0"/>
 		<joint name="joint_6-tool0" type="fixed">
 			<origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
 			<parent link="link_6"/>
 			<child link="tool0"/>
-		</joint>
+		</joint> -->
 </robot>

--- a/dsr_description2/urdf/m1013.urdf
+++ b/dsr_description2/urdf/m1013.urdf
@@ -230,11 +230,11 @@
 			</visual>
   </link>
 
-  <link name="tool0"/>
+  <!-- <link name="tool0"/>
   <joint name="joint_6-tool0" type="fixed">
     <origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
     <parent link="link_6"/>
     <child link="tool0"/>
-  </joint>
+  </joint> -->
   
 </robot>

--- a/dsr_description2/urdf/m1509.urdf
+++ b/dsr_description2/urdf/m1509.urdf
@@ -243,10 +243,10 @@
 				</geometry>
 			</visual>
 		</link>
-		<link name="tool0"/>
+	<!-- <link name="tool0"/>
   <joint name="joint_6-tool0" type="fixed">
     <origin rpy="3.1415926535 -1.570796327 0" xyz="0 0 0"/>
     <parent link="link_6"/>
     <child link="tool0"/>
-  </joint>
+  </joint> -->
 </robot>

--- a/dsr_moveit2/dsr_moveit_config_a0509/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_a0509/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_a0509/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_a0509/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_a0912/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_a0912/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_a0912/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_a0912/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_e0509/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_e0509/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_e0509/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_e0509/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_h2017/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_h2017/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_h2017/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_h2017/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_h2515/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_h2515/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_h2515/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_h2515/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_m0609/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_m0609/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_m0609/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_m0609/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_m0617/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_m0617/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_m0617/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_m0617/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_m1013/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_m1013/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_m1013/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_m1013/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_m1509/config/dsr.srdf
+++ b/dsr_moveit2/dsr_moveit_config_m1509/config/dsr.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="tool0" />
+        <chain base_link="base_link" tip_link="link_6" />
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="all-zeros" group="manipulator">

--- a/dsr_moveit2/dsr_moveit_config_m1509/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_m1509/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true

--- a/dsr_moveit2/dsr_moveit_config_p3020/launch/moveit.rviz
+++ b/dsr_moveit2/dsr_moveit_config_p3020/launch/moveit.rviz
@@ -101,10 +101,6 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        tool0:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
       Loop Animation: false
       Name: Trajectory
       Robot Alpha: 0.5
@@ -177,10 +173,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true
@@ -255,10 +247,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Loop Animation: false
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
@@ -343,10 +331,6 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-          tool0:
-            Alpha: 1
-            Show Axes: false
-            Show Trail: false
         Robot Alpha: 1
         Show Robot Collision: false
         Show Robot Visual: true


### PR DESCRIPTION
Related issue https://github.com/doosan-robotics/doosan-robot2/issues/193

Removed `tool0` from the URDF as it's not used in the provided launches.