### PR TITLE
Fix: safety state control

### DIFF
--- a/dsr_hardware2/src/dsr_hw_interface2.cpp
+++ b/dsr_hardware2/src/dsr_hw_interface2.cpp
@@ -365,7 +365,6 @@ CallbackReturn DRHWInterface::on_init(const hardware_interface::HardwareInfo & i
         if (!Drfl.set_accj_rt(limit)) return CallbackReturn::ERROR;
     }
     
-    Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS,SAFETY_MODE_EVENT_MOVE);
     return CallbackReturn::SUCCESS;
 }
 
@@ -489,7 +488,7 @@ return_type DRHWInterface::write(const rclcpp::Time &, const rclcpp::Duration &d
             // move_joint (drfl) API internally sent safety_off right after moving. 
             // which occurs problems like :
             // "move_joint service command -> trajectory command => error ! "
-            Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS,SAFETY_MODE_EVENT_MOVE);
+            Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS, SAFETY_MODE_EVENT_MOVE);
             idle = false;
         }
 
@@ -510,6 +509,9 @@ return_type DRHWInterface::write(const rclcpp::Time &, const rclcpp::Duration &d
         }
         pre_joint_position_command_ = joint_position_command_;
         return return_type::OK;
+    }
+    if(false == idle) {
+       Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS, SAFETY_MODE_EVENT_STOP);
     }
     idle = true;
     pre_joint_position_command_ = joint_position_command_;


### PR DESCRIPTION
Related Issue : https://github.com/DoosanRobotics/doosan-robot2/issues/197

### Description

At hardware initialization, the call to `Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS, SAFETY_MODE_EVENT_MOVE);` was causing issues, so it has been removed.

**Additional Information:**

In general, motion APIs handle the safety state internally, so there's usually no need to manage it explicitly. As far as I know, the only exception is the `servoj API` used in MoveIt, which doesn't handle safety internally.

This case is already managed in the `write section` of the hardware interface.
To handle the safety mode transitions:
  - Set `Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS, SAFETY_MODE_EVENT_MOVE);` only once, when detecting the initial change in joint positions.
  - Set `Drfl.set_safety_mode(SAFETY_MODE_AUTONOMOUS, SAFETY_MODE_EVENT_STOP); `only once, when detecting the initial point where joint positions stop changing.