### PR TITLE
Add missing dependency on libpoco-dev in packaes which need it

### DIFF
--- a/dsr_common2/package.xml
+++ b/dsr_common2/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>libpoco-dev</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/dsr_controller2/package.xml
+++ b/dsr_controller2/package.xml
@@ -28,6 +28,7 @@
   <depend>dsr_hardware2</depend>
   <depend>yaml-cpp</depend> 
   <depend>ament_index_cpp</depend>
+  <depend>libpoco-dev</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>controller_manager</test_depend>

--- a/dsr_hardware2/package.xml
+++ b/dsr_hardware2/package.xml
@@ -26,6 +26,7 @@
   <depend>trajectory_msgs</depend> 
   <depend>moveit_msgs</depend> 
   <depend>yaml-cpp</depend> 
+  <depend>libpoco-dev</depend>
   
   <build_depend>dsr_msgs2</build_depend>
 


### PR DESCRIPTION
Trying to build these packages in isolation I found out the dependency on `libpoco-dev` was not declared in packages which required it. I think this should fix the issue.