### PR TITLE
Apply controller configurations irrespective of namespace

### DIFF
--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -21,7 +21,7 @@
       dsr_position_controller:
         type: forward_command_controller/ForwardCommandController
 
-dsr_controller2:
+/**/dsr_controller2:
   ros__parameters:
     joints:
       - joint_1
@@ -31,7 +31,7 @@ dsr_controller2:
       - joint_5
       - joint_6
       
-dsr_position_controller:
+/**/dsr_position_controller:
   ros__parameters:
     joints:
       - joint_1
@@ -50,7 +50,7 @@ dsr_position_controller:
     #   - position
     #   - velocity
 
-dsr_joint_trajectory:
+/**/dsr_joint_trajectory:
   ros__parameters:
     joints:
       - joint_1
@@ -68,7 +68,7 @@ dsr_joint_trajectory:
       - position
       - velocity
 
-dsr_moveit_controller:
+/**/dsr_moveit_controller:
   ros__parameters:
     command_interfaces:
       - position

--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -21,66 +21,66 @@
       dsr_position_controller:
         type: forward_command_controller/ForwardCommandController
 
-/**/dsr_controller2:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-      
-/**/dsr_position_controller:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-    interface_name: position
+  dsr_controller2:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
+        
+  dsr_position_controller:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
+      interface_name: position
 
-    # command_interfaces:
-    #   - position
-    #   - velocity
+      # command_interfaces:
+      #   - position
+      #   - velocity
 
-    # state_interfaces:
-    #   - position
-    #   - velocity
+      # state_interfaces:
+      #   - position
+      #   - velocity
 
-/**/dsr_joint_trajectory:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
+  dsr_joint_trajectory:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
 
-    command_interfaces:
-      - position
-      - velocity
+      command_interfaces:
+        - position
+        - velocity
 
-    state_interfaces:
-      - position
-      - velocity
+      state_interfaces:
+        - position
+        - velocity
 
-/**/dsr_moveit_controller:
-  ros__parameters:
-    command_interfaces:
-      - position
-      - velocity
-    state_interfaces:
-      - position
-      - velocity
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
+  dsr_moveit_controller:
+    ros__parameters:
+      command_interfaces:
+        - position
+        - velocity
+      state_interfaces:
+        - position
+        - velocity
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
 


### PR DESCRIPTION
Without this change some of the controller configurations have no effect in the setups we tested, causing some of the controllers fail to configure.