### PR TITLE
Update CI Pipeline

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "humble" ]
   pull_request:
     branches: [ "humble" ]
-
 jobs:
   doosan-jobs: 
     runs-on: linux_x86_8core_runner 
@@ -91,4 +90,5 @@ jobs:
                         dsr_controller2      
                         dsr_msgs2
                         dsr_tests
+                        
           target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,6 +47,24 @@ jobs:
       - name: doosan emulator start
         run: sudo docker start emulator
 
+      - name: Check if port is open on localhost
+        run: |
+          PORT=12345  # Set the port you want to check
+          TIMEOUT=60  # Timeout for 1 minute
+          END_TIME=$(( $(date +%s) + TIMEOUT ))
+
+          echo "Checking if port $PORT is open on localhost for 1 minute..."
+          while [ $(date +%s) -lt $END_TIME ]; do
+            if nc -z localhost $PORT; then
+              echo "Port $PORT is open!"
+              exit 0
+            fi
+            echo "Port $PORT is not open. Retrying in 5 seconds..."
+            sleep 5
+          done
+          echo "Port $PORT is not open after 1 minute."
+          exit 1
+
       - name: build and test ROS 2
         if: ${{ matrix.ros_version == 2 }}
         uses: ros-tooling/action-ros-ci@v0.3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,8 +62,7 @@ jobs:
             sleep 5
           done
           echo "Port $PORT is not open after 1 minute."
-          exit 1
-
+          exit 1 
       - name: build and test ROS 2
         if: ${{ matrix.ros_version == 2 }}
         uses: ros-tooling/action-ros-ci@v0.3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -69,7 +69,6 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: dsr_moveit_config_a0912
-                        dsr_tests
                         dsr_moveit_config_h2515  
                         dsr_moveit_config_m1509  
                         dsr_moveit_config_e0509      

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   doosan-jobs: 
-    runs-on: linux_x86_8core_runner
+    runs-on: linux_x86_8core_runner 
     timeout-minutes: 25
     strategy:
       matrix:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   doosan-jobs: 
     runs-on: linux_x86_8core_runner 
-    timeout-minutes: 25
+    timeout-minutes: 30
     strategy:
       matrix:
         ros_distribution:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "humble" ]
   pull_request:
     branches: [ "humble" ]
-
 jobs:
   doosan-jobs: 
     runs-on: linux_x86_8core_runner 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,64 +7,70 @@ on:
     branches: [ "humble" ]
 
 jobs:
-  test_docker: # On Linux, iterates on all ROS 1 and ROS 2 distributions.
-    runs-on: ubuntu-latest
+  doosan-jobs: 
+    runs-on: linux_x86_8core_runner
+    timeout-minutes: 25
     strategy:
       matrix:
         ros_distribution:
           - humble
         include:
-          # Humble Hawksbill (May 2022 - May 2027)
           - docker_image: ubuntu:jammy
             ros_distribution: humble
             ros_version: 2
-    container:
-      image: ${{ matrix.docker_image }}
+    services:
+      emulator-server:
+        image: doosanrobot/dsr_emulator:3.0.1
+        ports:
+          - 12345:12345
+        options: --name emulator -i
+    env:
+      TEST_ON_CLOUD: true
     steps:
       - name: setup ROS environment 
         uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
+
       - name: doosan dependencies install - poco
-        run: apt-get install -y libpoco-dev libyaml-cpp-dev dbus-x11
+        run: sudo apt-get install -y libpoco-dev libyaml-cpp-dev dbus-x11
   
       - name: doosan dependencies install - Docker 
-        run: apt-get update && apt-get install -y ca-certificates curl && install -m 0755 -d /etc/apt/keyrings &&
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc &&
-            chmod a+r /etc/apt/keyrings/docker.asc && 
-            echo \
+        run: sudo apt-get update && sudo apt-get install -y ca-certificates && sudo install -m 0755 -d /etc/apt/keyrings &&
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc &&
+            sudo chmod a+r /etc/apt/keyrings/docker.asc && 
+            sudo echo \
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu 
             $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | 
-            tee /etc/apt/sources.list.d/docker.list > /dev/null
-            
-      - name: doosan dependencies install - Emulator
-        run: apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin &&
-            docker pull doosanrobot/dsr_emulator:3.0.1
-            
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+      - name: doosan emulator start
+        run: sudo docker start emulator
+
       - name: build and test ROS 2
         if: ${{ matrix.ros_version == 2 }}
         uses: ros-tooling/action-ros-ci@v0.3
         with:
-          package-name:  dsr_moveit_config_a0912
-                         dsr_moveit_config_h2515  
-                         dsr_moveit_config_m1509  
-                         dsr_moveit_config_e0509      
-                         dsr_moveit_config_m0609  
-                         dsr_moveit_config_m0617       
-                         dsr_moveit_config_a0509       
-                         dsr_moveit_config_h2017     
-                         dsr_moveit_config_m1013
-                         dsr_moveit_config_p3020
-                         dsr_description2 
-                         dsr_common2              
-                         dsr_gazebo2       
-                         dsr_realtime_control
-                         dsr_bringup2         
-                         dsr_hardware2     
-                         dsr_example               
-                         dsr_visualservoing
-                         dsr_controller2      
-                         dsr_msgs2         
-          # all packages except for 'dsr_tests'
-          
+          package-name: dsr_moveit_config_a0912
+                        dsr_tests
+                        dsr_moveit_config_h2515  
+                        dsr_moveit_config_m1509  
+                        dsr_moveit_config_e0509      
+                        dsr_moveit_config_m0609  
+                        dsr_moveit_config_m0617       
+                        dsr_moveit_config_a0509       
+                        dsr_moveit_config_h2017     
+                        dsr_moveit_config_m1013
+                        dsr_moveit_config_p3020
+                        dsr_description2 
+                        dsr_common2              
+                        dsr_gazebo2       
+                        dsr_realtime_control
+                        dsr_bringup2         
+                        dsr_hardware2     
+                        dsr_example               
+                        dsr_visualservoing
+                        dsr_controller2      
+                        dsr_msgs2
+                        dsr_tests
           target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "humble" ]
   pull_request:
     branches: [ "humble" ]
+
 jobs:
   doosan-jobs: 
     runs-on: linux_x86_8core_runner 

--- a/dsr_tests/launch/dsr_bringup_without_spawner_test.launch.py
+++ b/dsr_tests/launch/dsr_bringup_without_spawner_test.launch.py
@@ -15,7 +15,7 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from launch.actions import RegisterEventHandler,DeclareLaunchArgument, TimerAction
 from launch.event_handlers import OnProcessExit
-
+from launch.conditions import IfCondition
 
 def generate_launch_description():
     ARGUMENTS =[ 
@@ -26,9 +26,12 @@ def generate_launch_description():
         DeclareLaunchArgument('model', default_value = 'm1013',     description = 'ROBOT_MODEL'    ),
         DeclareLaunchArgument('color', default_value = 'white',     description = 'ROBOT_COLOR'    ),
         DeclareLaunchArgument('rt_host',    default_value = '192.168.137.50',     description = 'ROBOT_RT_IP'    ),
+        DeclareLaunchArgument('rviz',   default_value = 'false',     description = 'Start RViz2'    ),
+        DeclareLaunchArgument('start_emulator',   default_value = 'false',     description = 'Start emulator'    ),
     ]
     xacro_path = os.path.join( get_package_share_directory('dsr_description2'), 'xacro')
-    # gui = LaunchConfiguration("gui")
+    rviz = LaunchConfiguration("rviz")
+    start_emulator = LaunchConfiguration("start_emulator")
     
     # Get URDF via xacro
     robot_description_content = Command(
@@ -96,6 +99,7 @@ def generate_launch_description():
             #parameters_file_path       # 파라미터 설정을 동일이름으로 launch 파일과 yaml 파일에서 할 경우 yaml 파일로 셋팅된다.    
         ],
         output="screen",
+        condition=IfCondition(start_emulator),
     )
 
     control_node = Node(
@@ -126,7 +130,7 @@ def generate_launch_description():
         name="rviz2",
         output="log",
         arguments=["-d", rviz_config_file],
-        # condition=IfCondition(gui),
+        condition=IfCondition(rviz),
     )
     
     # Delay start of robot_controller after `joint_state_broadcaster`
@@ -136,7 +140,6 @@ def generate_launch_description():
             on_exit=[control_node],
         )
     )
-    
 
     nodes = [
         set_config_node,

--- a/dsr_tests/package.xml
+++ b/dsr_tests/package.xml
@@ -14,9 +14,9 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>dsr_msgs2</test_depend>
-  <!-- <test_depend>dsr_description2</test_depend>
+  <test_depend>dsr_description2</test_depend>
   <test_depend>dsr_controller2</test_depend>
-  <test_depend>dsr_bringup2</test_depend> -->
+  <test_depend>dsr_bringup2</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/dsr_tests/package.xml
+++ b/dsr_tests/package.xml
@@ -14,8 +14,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>dsr_msgs2</test_depend>
-  <!-- <test_depend>dsr_description2</test_depend>
-  <test_depend>dsr_controller2</test_depend> -->
+  <test_depend>dsr_description2</test_depend>
+  <test_depend>dsr_controller2</test_depend>
   <test_depend>dsr_bringup2</test_depend>
 
   <export>

--- a/dsr_tests/package.xml
+++ b/dsr_tests/package.xml
@@ -14,10 +14,9 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>dsr_msgs2</test_depend>
-  <test_depend>dsr_description2</test_depend>
+  <!-- <test_depend>dsr_description2</test_depend>
   <test_depend>dsr_controller2</test_depend>
-  <test_depend>dsr_bringup2</test_depend>
-
+  <test_depend>dsr_bringup2</test_depend> -->
 
   <export>
     <build_type>ament_python</build_type>

--- a/dsr_tests/package.xml
+++ b/dsr_tests/package.xml
@@ -15,6 +15,10 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>dsr_msgs2</test_depend>
   <test_depend>dsr_description2</test_depend>
+  <test_depend>dsr_controller2</test_depend>
+  <test_depend>dsr_bringup2</test_depend>
+
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/dsr_tests/package.xml
+++ b/dsr_tests/package.xml
@@ -14,6 +14,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>dsr_msgs2</test_depend>
+  <test_depend>dsr_description2</test_depend>
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/dsr_tests/package.xml
+++ b/dsr_tests/package.xml
@@ -14,8 +14,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>dsr_msgs2</test_depend>
-  <test_depend>dsr_description2</test_depend>
-  <test_depend>dsr_controller2</test_depend>
+  <!-- <test_depend>dsr_description2</test_depend>
+  <test_depend>dsr_controller2</test_depend> -->
   <test_depend>dsr_bringup2</test_depend>
 
   <export>

--- a/dsr_tests/test/test_cli_dsr_system.py
+++ b/dsr_tests/test/test_cli_dsr_system.py
@@ -9,6 +9,7 @@ from dsr_msgs2.srv import *
 import rclpy.duration
 from std_msgs.msg import Float64MultiArray, MultiArrayDimension
 import rclpy.type_support
+import os
 
 ### !Note: Currently, real mode doesn't work. (TODO)
 MODE = 'virtual'
@@ -17,6 +18,19 @@ MODEL = 'm1013'
 SRV_CALL_TIMEOUT = 30	
 PORT = 12345
 
+RVIZ = True
+START_EMULATOR = True 
+
+
+
+### In case of cloud ci pipeline, 
+### we don't need turn on rviz and 
+### emulator should be already setup at pipeline configuration.
+if os.getenv("TEST_ON_CLOUD", "false") == "true":
+	print("START TEST CODE ON CLOUD ENVIRONMENT !!")
+	RVIZ = False
+	START_EMULATOR = False
+	
 
 @pytest.fixture(scope='session', autouse=True)
 def bringUp():
@@ -29,7 +43,9 @@ def bringUp():
 			"dsr_bringup_without_spawner_test.launch.py",
 			"mode:={}".format(MODE),
 			"name:={}".format(NAMESPACE),
-			"port:={}".format(PORT)
+			"port:={}".format(PORT),
+			"rviz:={}".format(RVIZ),
+			"start_emulator:={}".format(START_EMULATOR)
 			],
 			stdout=subprocess.PIPE,
 			stderr=subprocess.STDOUT,

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+colcon test --event-handlers console_direct+ console_package_list+ --pytest-args --capture=no --packages-select dsr_tests


### PR DESCRIPTION
The previous CI pipeline did not check the `dsr_tests`, which describe integration tests. This configuration includes those tests.

I’d like to point out a few things regarding the CI pipeline configuration:

For our integration tests, we need to start an emulator container with port `12345` bound. This process should run in the background. Similarly, when running integration tests for the web server and database, they encounter similar issues. To address this, the configuration uses the `services:` keyword, as GitHub Actions' services feature seems to follow the pattern of Docker Compose services.

Please note that **the `--net host` option doesn’t work in this setup.** Configuring network settings for GitHub-hosted runners is particularly tricky.

An important change I made was deleting the `container:` option, which defines the base container to run jobs. This option requires the Bridge network driver. **By removing it, jobs now run directly on the runner machine, allowing access to open ports on localhost.** For more information, see: [GitHub Docs on Service Containers](https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers#communicating-with-service-containers).
