### PR TITLE
Add RobotDisconnection event publisher

### DIFF
--- a/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
+++ b/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
@@ -47,6 +47,7 @@
 #include <dsr_msgs2/msg/speedl_rt_stream.hpp>
 #include <dsr_msgs2/msg/torque_rt_stream.hpp>
 #include <dsr_msgs2/msg/robot_error.hpp>
+#include <dsr_msgs2/msg/robot_disconnection.hpp>
 
 
 
@@ -502,6 +503,7 @@ namespace DRFL_CALLBACKS {
   void OnMonitoringAccessControlCB(const MONITORING_ACCESS_CONTROL eAccCtrl);
   void OnLogAlarm(LPLOG_ALARM pLogAlarm);
   void OnMonitoringDataExCB(const LPMONITORING_DATA_EX pData);
+  void OnDisConnected();
 }
 
 
@@ -550,6 +552,7 @@ public:
   controller_interface::CallbackReturn on_shutdown(
     const rclcpp_lifecycle::State & previous_state) override;
   
+  rclcpp::Publisher<dsr_msgs2::msg::RobotDisconnection>::SharedPtr disconnect_pub_;
   rclcpp::Publisher<dsr_msgs2::msg::RobotError>::SharedPtr error_log_pub_;
 protected:
   std::vector<std::string> joint_names_;

--- a/dsr_msgs2/CMakeLists.txt
+++ b/dsr_msgs2/CMakeLists.txt
@@ -28,7 +28,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ServolStream.msg"
   "msg/SpeedjStream.msg"
   "msg/SpeedlStream.msg"
-
+  "msg/RobotDisconnection.msg"
   "msg/RobotStateRt.msg"
   "msg/ServojRtStream.msg"
   "msg/ServolRtStream.msg"

--- a/dsr_msgs2/msg/RobotDisconnection.msg
+++ b/dsr_msgs2/msg/RobotDisconnection.msg
@@ -1,0 +1,1 @@
+### Event driven when the robot connection losts.


### PR DESCRIPTION

Regarding issue #208,
we encountered a network timeout, but the system failed to detect it.
This update adds a log message and `RobotDisconnection` message will be published when this happens.