### PR TITLE
Revise joint pose for M0609, M1509, M0617 and A0509 XACRO files.

### DIFF
--- a/dsr_description2/xacro/macro.a0509.blue.xacro
+++ b/dsr_description2/xacro/macro.a0509.blue.xacro
@@ -32,7 +32,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1555" />
+			<origin rpy="0 0 0" xyz="0 0 0.1560" />
 			<axis xyz="0 0 1" />
 			<limit effort="194" lower="-6.2832" upper="6.2832" velocity="3.1416"/>
 			<dynamics friction="0" />

--- a/dsr_description2/xacro/macro.a0509.white.xacro
+++ b/dsr_description2/xacro/macro.a0509.white.xacro
@@ -31,7 +31,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1555" />
+			<origin rpy="0 0 0" xyz="0 0 0.1560" />
 			<axis xyz="0 0 1" />
 			<limit effort="194" lower="-6.2832" upper="6.2832" velocity="3.1416"/>
 			<dynamics friction="0" />

--- a/dsr_description2/xacro/macro.m0609.blue.xacro
+++ b/dsr_description2/xacro/macro.m0609.blue.xacro
@@ -31,7 +31,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1" />
+			<origin rpy="0 0 0" xyz="0 0 0.1345" />
 			<axis xyz="0 0 1" />
 			<limit effort="163" lower="-6.2832" upper="6.2832" velocity="2.618"/>
 			<dynamics friction="0" />

--- a/dsr_description2/xacro/macro.m0609.white.xacro
+++ b/dsr_description2/xacro/macro.m0609.white.xacro
@@ -31,7 +31,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1" />
+			<origin rpy="0 0 0" xyz="0 0 0.1345" />
 			<axis xyz="0 0 1" />
 			<limit effort="163" lower="-6.2832" upper="6.2832" velocity="2.618"/>
 			<dynamics friction="0" />

--- a/dsr_description2/xacro/macro.m0617.blue.xacro
+++ b/dsr_description2/xacro/macro.m0617.blue.xacro
@@ -31,7 +31,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1525" />
+			<origin rpy="0 0 0" xyz="0 0 0.1530" />
 			<axis xyz="0 0 1" />
 			<limit effort="346" lower="-6.2832" upper="6.2832" velocity="1.7453"/>
 			<dynamics friction="0" />

--- a/dsr_description2/xacro/macro.m0617.white.xacro
+++ b/dsr_description2/xacro/macro.m0617.white.xacro
@@ -31,7 +31,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1525" />
+			<origin rpy="0 0 0" xyz="0 0 0.1530" />
 			<axis xyz="0 0 1" />
 			<limit effort="346" lower="-6.2832" upper="6.2832" velocity="1.7453"/>
 			<dynamics friction="0" />

--- a/dsr_description2/xacro/macro.m1509.blue.xacro
+++ b/dsr_description2/xacro/macro.m1509.blue.xacro
@@ -31,7 +31,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1525" />
+			<origin rpy="0 0 0" xyz="0 0 0.1530" />
 			<axis xyz="0 0 1" />
 			<limit effort="346" lower="-6.2832" upper="6.2832" velocity="2.618"/>
 			<dynamics friction="0" />

--- a/dsr_description2/xacro/macro.m1509.white.xacro
+++ b/dsr_description2/xacro/macro.m1509.white.xacro
@@ -31,7 +31,7 @@
 		<joint name="joint_1" type="revolute">
 			<parent link="base_link" />
 			<child link="link_1" />
-			<origin rpy="0 0 0" xyz="0 0 0.1525" />
+			<origin rpy="0 0 0" xyz="0 0 0.1530" />
 			<axis xyz="0 0 1" />
 			<limit effort="346" lower="-6.2832" upper="6.2832" velocity="2.618"/>
 			<dynamics friction="0" />


### PR DESCRIPTION
Revised pose of robot description for simulation. 

Several links were actually colliding each other. This wasn't problematic while moving in Gazebo. But when using MuJoCo, those collisions lead to large, unpredictable movements.

- M0609 before the change:
![Screenshot from 2025-06-23 15-21-31](https://github.com/user-attachments/assets/33a841e2-752f-4737-aa11-30bf3e801ba4)
You can clearly see the narrow gaps between the other links. But not the one from base to link_1, which cause trouble using realistic simulations.

 For the consistency with other links and for future use in realistic simulation (like MuJoCo). I have added offsets for those cases.

- M0609 after the change:
![Screenshot from 2025-06-23 15-19-39](https://github.com/user-attachments/assets/11238244-0b5a-4c46-9a92-686f827f2482)
Increased the Z-axis value for the first joint.

Simillar cases were also observed in M1509, M0617, A0509 model, and were modified respectively.

You can test each of the updates with the following CLI:
- M0609
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=m0609
```
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=m0609 color:=blue
```
- M1509
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=m1509
```
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=m1509 color:=blue
```
- M0617
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=m0617
```
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=m0617 color:=blue
```
- A0509
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=a0509
```
```
ros2 launch dsr_bringup2 dsr_bringup2_gazebo.launch.py gui:=true model:=a0509 color:=blue
```