### PR TITLE
fix(get_tool_force): apply ref parameter and output values per coordi…

### DIFF
--- a/dsr_common2/imp/DSR_ROBOT2.py
+++ b/dsr_common2/imp/DSR_ROBOT2.py
@@ -1190,16 +1190,15 @@ def get_external_torque():
 
 def get_tool_force(ref=None):
 
-    # ref
-    if ref == None:
-        _ref = DR_BASE
-    else:
-        _ref = ref
-        if _ref != DR_BASE and _ref != DR_WORLD:
-            raise DR_Error(DR_ERROR_VALUE, "Invalid value : ref({0})".format(_ref))
+    _ref = DR_BASE if ref is None else ref
+
+    if _ref not in [DR_BASE, DR_TOOL, DR_WORLD]:
+        raise DR_Error(DR_ERROR_VALUE, f"Invalid value : ref({_ref})")
+
+    ret = -1
 
     if __ROS2__:
-        req =  GetToolForce.Request()  
+        req = GetToolForce.Request()
         req.ref = _ref
 
         future = _ros2_get_tool_force.call_async(req)
@@ -1207,13 +1206,13 @@ def get_tool_force(ref=None):
 
         try:
             result = future.result()
+            if result and result.success:
+                ret = list(result.tool_force)
+            else:
+                g_node.get_logger().warn("get_tool_force: service call returned unsuccessful or empty result")
         except Exception as e:
-            g_node.get_logger().info('get_tool_force Service call failed %r' % (e,))
-        else:
-            if result == None:
-                ret = -1    
-            else:        
-                ret = list(result.tool_force)  # Convert tuple to list  
+            g_node.get_logger().error(f"get_tool_force: service call failed - {e}")
+
     return ret
 
 def get_solution_space(pos):

--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -846,16 +846,63 @@ auto get_external_torque_cb = [this](const std::shared_ptr<dsr_msgs2::srv::GetEx
     res->success = true;        
 };
 
-auto get_tool_force_cb = [this](const std::shared_ptr<dsr_msgs2::srv::GetToolForce::Request> /*req*/, std::shared_ptr<dsr_msgs2::srv::GetToolForce::Response> res)                          
+auto get_tool_force_cb = [this](const std::shared_ptr<dsr_msgs2::srv::GetToolForce::Request> req,
+                                std::shared_ptr<dsr_msgs2::srv::GetToolForce::Response> res)
 {
 #if (_DEBUG_DSR_CTL)
-    RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"< get_tool_force_cb >");
+    RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"), "< get_tool_force_cb > ref: %d", req->ref);
 #endif
-    //NO API , get mon_data
-    for(int i = 0; i < NUM_TASK; i++){
-        res->tool_force[i] = g_stDrState.fActualETT[i];
+
+    // Load rotation matrix from base to tool (3x3)
+    float R[3][3];
+    for (int r = 0; r < 3; r++)
+        for (int c = 0; c < 3; c++)
+            R[r][c] = g_stDrState.fRotationMatrix[r][c];
+
+    switch (req->ref) {
+        case 0:  // BASE frame (default): use raw ETT values directly
+            for (int i = 0; i < NUM_TASK; i++)
+                res->tool_force[i] = g_stDrState.fActualETT[i];
+            break;
+
+        case 1: {  // TOOL frame: apply coordinate transformation
+            double force_base[3] = {
+                g_stDrState.fActualETT[0],
+                g_stDrState.fActualETT[1],
+                g_stDrState.fActualETT[2]
+            };
+            
+            double torque_tool[3] = {
+                g_stDrState.fActualETT[3],
+                g_stDrState.fActualETT[4],
+                g_stDrState.fActualETT[5]
+            };
+
+            // Convert force to tool frame:
+            for (int i = 0; i < 3; i++) {
+                res->tool_force[i] = 0.0;
+                for (int j = 0; j < 3; j++)
+                    res->tool_force[i] += R[j][i] * force_base[j];
+            }
+            res->tool_force[3] = torque_tool[0];
+            res->tool_force[4] = torque_tool[1];
+            res->tool_force[5] = torque_tool[2];
+            break;
+        }
+
+        case 2:  // WORLD frame: directly use precomputed values from monitoring
+            for (int i = 0; i < NUM_TASK; i++)
+                res->tool_force[i] = g_stDrState.fWorldETT[i];
+            break;
+
+        default: 
+            RCLCPP_WARN(rclcpp::get_logger("dsr_controller2"),
+                        "[get_tool_force_cb] Invalid ref: %d. Defaulting to BASE frame.", req->ref);
+            for (int i = 0; i < NUM_TASK; i++)
+                res->tool_force[i] = g_stDrState.fActualETT[i];
+            break;
     }
-    res->success = true;        
+    res->success = true;
 };
 
 auto get_solution_space_cb = [this](const std::shared_ptr<dsr_msgs2::srv::GetSolutionSpace::Request> req, std::shared_ptr<dsr_msgs2::srv::GetSolutionSpace::Response> res)-> void


### PR DESCRIPTION
Fix /get_tool_force so the ref parameter is actually honored.
Now the service returns the wrench expressed in the requested frame for Force.

DSR_ROBOT2.py
- Forward the ref parameter to the service request as-is (0: BASE, 1: TOOL, 2: WORLD).
- Added input validation: reject invalid ref (only {0,1,2} allowed).

dsr_controller2.cpp
- Implemented switch (req->ref) in get_tool_force_cb(...) to honor ref.
- Load the base→tool rotation matrix once and reuse it.
- BASE (ref=0): Force = fActualETT[0..2] (BASE); Torque = fActualETT[3..5] (TOOL).
- TOOL (ref=1): Force transformed to TOOL with F_tool = Rᵀ * F_base; Torque unchanged (TOOL).
- WORLD (ref=2): Force = fWorldETT[0..2] (WORLD); Torque unchanged (TOOL).

#245
