### PR TITLE
Update for auto python path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     
 This package provides the function to control all models of Doosan robots in the ROS2(Humble) environment.
 
+For tutorials and more information, please refer to the [official Doosan Robotics ROS2 manual](https://doosanrobotics.github.io/doosan-robotics-ros-manual/humble/index.html).
 
 ## Installation
 

--- a/dsr_common2/CMakeLists.txt
+++ b/dsr_common2/CMakeLists.txt
@@ -12,6 +12,16 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
+# Find Python for automatic version setting
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Install Python modules to site-packages
+install(DIRECTORY imp/ 
+  DESTINATION lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/
+  FILES_MATCHING PATTERN "*.py"
+  PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+)
+
 ament_package()
 
 #install(PROGRAMS 


### PR DESCRIPTION
Now there is no need to manualy add python path in bashrc.

Update dsr_common2/CMakeLists.txt