### PR TITLE
fix: missing hw interface params

### DIFF
--- a/dsr_bringup2/launch/dsr_bringup2_spawn_on_gazebo.launch.py
+++ b/dsr_bringup2/launch/dsr_bringup2_spawn_on_gazebo.launch.py
@@ -70,6 +70,12 @@ def generate_launch_description():
                 ]
             ),
             ".urdf.xacro",
+            " name:=", LaunchConfiguration('name'),
+            " host:=", LaunchConfiguration('host'),
+            " rt_host:=", LaunchConfiguration('rt_host'),
+            " port:=", LaunchConfiguration('port'),
+            " mode:=", LaunchConfiguration('mode'),
+            " model:=", LaunchConfiguration('model'),
         ]
     )
 
@@ -218,6 +224,7 @@ def generate_launch_description():
     
 
     nodes = [
+        set_use_sim_time,
         run_emulator_node,
         gazebo_connection_node,
         robot_state_pub_node,


### PR DESCRIPTION
Fixes the gazebo spawn script not setting the [parameters needed by hw_interface](https://github.com/DoosanRobotics/doosan-robot2/blob/humble/dsr_hardware2/src/dsr_hw_interface2.cpp#L51-L76). 

The [main script already set them in the same way.](https://github.com/DoosanRobotics/doosan-robot2/blob/humble/dsr_bringup2/launch/dsr_bringup2_gazebo.launch.py#L70-L77)