### PR TITLE
Fix move spiral missing parameters

### DIFF
--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -436,19 +436,74 @@ auto moveb_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveBlending::Reque
 auto movespiral_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveSpiral::Request> req, std::shared_ptr<dsr_msgs2::srv::MoveSpiral::Response> res)-> void          
 {
     res->success = false;
+    std::array<float, 3> target_pos;
     std::array<float, 2> target_vel;
-    
     std::array<float, 2> target_acc;
+    std::copy(req->target_pos.cbegin(), req->target_pos.cend(), target_pos.begin());
     std::copy(req->vel.cbegin(), req->vel.cend(), target_vel.begin());
     std::copy(req->acc.cbegin(), req->acc.cend(), target_acc.begin());
 
+    bool use_spiral_ex = std::any_of(req->target_pos.cbegin(), req->target_pos.cend(), [](float v){ return v != 0.0; });
+
     if(req->sync_type == 0){
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movespiral_cb() called and calling Drfl->move_spiral");
-        res->success = Drfl->move_spiral((TASK_AXIS)req->task_axis, req->revolution, req->max_radius, req->max_length, target_vel.data(), target_acc.data(), req->time, (MOVE_REFERENCE)req->ref);
+        if (use_spiral_ex){
+            RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movespiral_cb() called and calling Drfl->move_spiral_ex");
+            res->success = Drfl->move_spiral(
+                (TASK_AXIS)req->task_axis,
+                req->revolution,
+                target_pos.data(),
+                target_vel.data(),
+                target_acc.data(),
+                req->time,
+                (MOVE_REFERENCE)req->ref,
+                (MOVE_MODE)req->mode,
+                (SPIRAL_DIR)req->spiral_dir,
+                (ROT_DIR)req->rot_dir
+            );
+        }
+        else {
+            RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movespiral_cb() called and calling Drfl->move_spiral");
+            res->success = Drfl->move_spiral(
+                (TASK_AXIS)req->task_axis,
+                req->revolution,
+                req->max_radius,
+                req->max_length,
+                target_vel.data(),
+                target_acc.data(),
+                req->time,
+                (MOVE_REFERENCE)req->ref
+            );
+        }
     }
     else{
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movespiral_cb() called and calling Drfl->amove_spiral");
-        res->success = Drfl->amove_spiral((TASK_AXIS)req->task_axis, req->revolution, req->max_radius, req->max_length, target_vel.data(), target_acc.data(), req->time, (MOVE_REFERENCE)req->ref);
+        if (use_spiral_ex){
+            RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movespiral_cb() called and calling Drfl->amove_spiral_ex");
+            res->success = Drfl->amove_spiral(
+                (TASK_AXIS)req->task_axis,
+                req->revolution,
+                target_pos.data(),
+                target_vel.data(),
+                target_acc.data(),
+                req->time,
+                (MOVE_REFERENCE)req->ref,
+                (MOVE_MODE)req->mode,
+                (SPIRAL_DIR)req->spiral_dir,
+                (ROT_DIR)req->rot_dir
+            );
+        }
+        else {
+            RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movespiral_cb() called and calling Drfl->amove_spiral");
+            res->success = Drfl->amove_spiral(
+                (TASK_AXIS)req->task_axis,
+                req->revolution,
+                req->max_radius,
+                req->max_length,
+                target_vel.data(),
+                target_acc.data(),
+                req->time,
+                (MOVE_REFERENCE)req->ref
+            );
+        }
     }
 };
 

--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -278,11 +278,11 @@ auto movejx_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveJointx::Reques
     std::copy(req->pos.cbegin(), req->pos.cend(), target_pos.begin());
     check_dsr_model(target_pos);
     if(req->sync_type == 0){
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->movejx");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->movejx");
         res->success = Drfl->movejx(target_pos.data(), req->sol, req->vel, req->acc, req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref, req->radius, (BLENDING_SPEED_TYPE)req->blend_type);    
     }
     else{
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->amovejx");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->amovejx");
         res->success = Drfl->amovejx(target_pos.data(), req->sol, req->vel, req->acc, req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref, (BLENDING_SPEED_TYPE)req->blend_type);    
     }
 };
@@ -308,11 +308,11 @@ auto movec_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveCircle::Request
     ///RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"  <xxx pos1> %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f",fTargetPos[0][0],fTargetPos[0][1],fTargetPos[0][2],fTargetPos[0][3],fTargetPos[0][4],fTargetPos[0][5]);
     ///RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"  <xxx pos2> %7.3f %7.3f %7.3f %7.3f %7.3f %7.3f",fTargetPos[1][0],fTargetPos[1][1],fTargetPos[1][2],fTargetPos[1][3],fTargetPos[1][4],fTargetPos[1][5]);
     if(req->sync_type == 0){   
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movec_cb() called and calling Drfl->movec");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movec_cb() called and calling Drfl->movec");
         res->success = Drfl->movec(fTargetPos, fTargetVel, fTargetAcc, req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref, req->angle1, req->angle2, req->radius, (BLENDING_SPEED_TYPE)req->blend_type);      
     }
     else{
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movec_cb() called and calling Drfl->amovec");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movec_cb() called and calling Drfl->amovec");
         res->success = Drfl->amovec(fTargetPos, fTargetVel, fTargetAcc, req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref, req->angle1, req->angle2, (BLENDING_SPEED_TYPE)req->blend_type);
     }
 };
@@ -350,12 +350,12 @@ auto movesj_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveSplineJoint::R
 
 
     if(req->sync_type == 0){
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->movesj");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->movesj");
         //res->success = Drfl->MoveSJ(fTargetPos, req->pos_cnt, fTargetVel, req->acc, req->time, (MOVE_MODE)req->mode);
         res->success = Drfl->movesj(fTargetPos, req->pos_cnt, fTargetVel, fTargetAcc, req->time, (MOVE_MODE)req->mode); //need updata API
     }
     else{
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->amovesj");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movejx_cb() called and calling Drfl->amovesj");
         //res->success = Drfl->MoveSJAsync(fTargetPos, req->pos_cnt, fTargetVel, fTargetAcc, req->time, (MOVE_MODE)req->mode);
         res->success = Drfl->amovesj(fTargetPos, req->pos_cnt, fTargetVel, fTargetAcc, req->time, (MOVE_MODE)req->mode); //need updata API
     }
@@ -381,11 +381,11 @@ auto movesx_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveSplineTask::Re
         fTargetAcc[i] = req->acc[i];
     }
     if(req->sync_type == 0){
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movesx_cb() called and calling Drfl->movesx");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movesx_cb() called and calling Drfl->movesx");
         res->success = Drfl->movesx(fTargetPos, req->pos_cnt, fTargetVel, fTargetAcc, req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref, (SPLINE_VELOCITY_OPTION)req->opt);
     }
     else{
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movesx_cb() called and calling Drfl->amovesx");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movesx_cb() called and calling Drfl->amovesx");
         res->success = Drfl->amovesx(fTargetPos, req->pos_cnt, fTargetVel, fTargetAcc, req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref, (SPLINE_VELOCITY_OPTION)req->opt);
     }
 };
@@ -424,11 +424,11 @@ auto moveb_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveBlending::Reque
     std::copy(req->acc.cbegin(), req->acc.cend(), target_acc.begin());
 
     if(req->sync_type == 0){
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"moveb_cb() called and calling Drfl->moveb");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"moveb_cb() called and calling Drfl->moveb");
         res->success = Drfl->moveb(posb, req->pos_cnt, target_vel.data(), target_acc.data(), req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref);
     }
     else{
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"moveb_cb() called and calling Drfl->amoveb");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"moveb_cb() called and calling Drfl->amoveb");
         res->success = Drfl->amoveb(posb, req->pos_cnt, target_vel.data(), target_acc.data(), req->time, (MOVE_MODE)req->mode, (MOVE_REFERENCE)req->ref);
     }
 };
@@ -515,7 +515,7 @@ auto moveperiodic_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MovePeriodic
     std::copy(req->amp.cbegin(), req->amp.cend(), target_amp.begin());
     std::copy(req->periodic.cbegin(), req->periodic.cend(), target_periodic.begin());
     if(req->sync_type == 0){
-        //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"moveperiodic_cb() called and calling Drfl->move_periodic");
+        RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"moveperiodic_cb() called and calling Drfl->move_periodic");
         res->success = Drfl->move_periodic(target_amp.data(), target_periodic.data(), req->acc, req->repeat, (MOVE_REFERENCE)req->ref);
     }
     else{
@@ -526,7 +526,7 @@ auto moveperiodic_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MovePeriodic
 
 auto movewait_cb = [this](const std::shared_ptr<dsr_msgs2::srv::MoveWait::Request> /*req*/, std::shared_ptr<dsr_msgs2::srv::MoveWait::Response> res)-> void                
 {
-    //RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movewait_cb() called and calling Drfl->mwait");
+    RCLCPP_INFO(rclcpp::get_logger("dsr_controller2"),"movewait_cb() called and calling Drfl->mwait");
     res->success = Drfl->mwait();
 };
 

--- a/dsr_msgs2/srv/motion/MoveSpiral.srv
+++ b/dsr_msgs2/srv/motion/MoveSpiral.srv
@@ -1,16 +1,20 @@
 #____________________________________________________________________________________________
-# move_sprial  
+# move_spiral  
 #____________________________________________________________________________________________
 
 float64    revolution       # Total number of revolutions 
-float64    max_radius        # Final spiral radius [mm]
-float64    max_length        # Distance moved in the axis direction [mm]
+float64    max_radius       # Final spiral radius [mm]
+float64    max_length       # Distance moved in the axis direction [mm]
+float64[3] target_pos       # Target position [mm]. If used, max_radius and max_length are ignored
 float64[2] vel              # set velocity: [mm/sec], [deg/sec]
 float64[2] acc              # set acceleration: [mm/sec2], [deg/sec2]
 float64    time #= 0.0      # Total execution time <sec> 
-int8       task_axis         # TASK_AXIS_X = 0, TASK_AXIS_Y = 1, TASK_AXIS_Z = 2   
+int8       task_axis        # TASK_AXIS_X = 0, TASK_AXIS_Y = 1, TASK_AXIS_Z = 2   
 int8       ref  #= 1        # DR_BASE(0), DR_TOOL(1), DR_WORLD(2)
                             # <DR_WORLD is only available in M2.40 or later 
-int8       sync_type #=0     # SYNC = 0, ASYNC = 1 
+int8       mode #= 0        # MOVE_MODE_ABSOLUTE=0, MOVE_MODE_RELATIVE=1 
+int8       spiral_dir #= 0  # MOVE_SPIRAL_OUTWARD=0, MOVE_SPIRAL_INWARD=1
+int8       rot_dir #=0      # MOVE_SPIRAL_FORWARD=0, MOVE_SPIRAL_REVERSE=1 
+int8       sync_type #=0    # SYNC = 0, ASYNC = 1 
 ---
 bool success


### PR DESCRIPTION
- Add missing move spiral parameters
- Call either move_spiral or move_spiral_ex depending on the given parameters.