### PR TITLE
Add option to move TF to robot namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ ros2 launch dsr_bringup2 dsr_bringup2_spawn_on_gazebo.launch.py mode:=virtual ho
 ```
 
 **Note:** Ensure each additional arm has a unique `port`, `name`, and location (`x`, `y`) to avoid collisions in Gazebo.
+**Note:** When launching multiple robots, we recommend using `remap_tf:=true` on `dsr_bringup2_gazebo` and `dsr_bringup2_spawn_on_gazebo`, to separate the robot TFs.
+
 
 ### Launch with **MoveIt2**
 

--- a/dsr_bringup2/launch/dsr_bringup2_gazebo.launch.py
+++ b/dsr_bringup2/launch/dsr_bringup2_gazebo.launch.py
@@ -12,12 +12,12 @@ from launch import LaunchDescription
 from launch.actions import RegisterEventHandler,DeclareLaunchArgument
 from launch.event_handlers import OnProcessExit
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration, PythonExpression
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetRemap
 from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
-from launch.actions import IncludeLaunchDescription, SetLaunchConfiguration
+from launch.actions import IncludeLaunchDescription, SetLaunchConfiguration, GroupAction
 
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import OpaqueFunction
@@ -48,6 +48,7 @@ def generate_launch_description():
         DeclareLaunchArgument('Y',   default_value = '0',     description = 'Location Yaw on Gazebo'    ),
         DeclareLaunchArgument('rt_host',    default_value = '192.168.137.50',     description = 'ROBOT_RT_IP'    ),
         DeclareLaunchArgument('use_sim_time', default_value='true', description='Use simulation time'),
+        DeclareLaunchArgument('remap_tf',   default_value = 'false',     description = 'REMAP TF'    ),
     ]
     
     set_use_sim_time = SetLaunchConfiguration(name='use_sim_time', value='true')
@@ -129,6 +130,7 @@ def generate_launch_description():
         parameters=[robot_description, robot_controllers],
         # output="both",
     )
+    
     robot_state_pub_node = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
@@ -136,8 +138,9 @@ def generate_launch_description():
         namespace=LaunchConfiguration('name'),
         output='both',
         parameters=[{
-        'robot_description': Command(['xacro', ' ', xacro_path, '/', LaunchConfiguration('model'), '.urdf.xacro color:=', LaunchConfiguration('color')])
-    }])
+            'robot_description': Command(['xacro', ' ', xacro_path, '/', LaunchConfiguration('model'), '.urdf.xacro color:=', LaunchConfiguration('color')])
+        }],
+    )
     
     rviz_node = Node(
         package="rviz2",
@@ -147,14 +150,6 @@ def generate_launch_description():
         output="log",
         arguments=["-d", rviz_config_file],
         condition=IfCondition(gui),
-    )
-
-    joint_state_broadcaster_spawner = Node(
-        package="controller_manager",
-        namespace=LaunchConfiguration('name'),
-        executable="spawner",
-        arguments=["joint_state_broadcaster", "-c", "controller_manager"],
-        parameters=[PathJoinSubstitution([FindPackageShare("dsr_controller2"), "config", "joint_state_broadcaster.yaml"])]
     )
 
     robot_controller_spawner = Node(
@@ -170,6 +165,32 @@ def generate_launch_description():
             target_action=robot_controller_spawner,
             on_exit=[rviz_node],
         )
+    )
+
+    original_tf_nodes = GroupAction(
+        actions=[
+            robot_state_pub_node,
+            rviz_node
+        ],
+        condition=UnlessCondition(LaunchConfiguration('remap_tf'))
+    )
+
+    remapped_tf_nodes = GroupAction(
+        actions=[
+            SetRemap(src='/tf', dst='tf'),
+            SetRemap(src='/tf_static', dst='tf_static'),
+            robot_state_pub_node,
+            rviz_node
+        ],
+        condition=IfCondition(LaunchConfiguration('remap_tf'))
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        namespace=LaunchConfiguration('name'),
+        executable="spawner",
+        arguments=["joint_state_broadcaster", "-c", "controller_manager"],
+        parameters=[PathJoinSubstitution([FindPackageShare("dsr_controller2"), "config", "joint_state_broadcaster.yaml"])]
     )
 
 
@@ -193,7 +214,7 @@ def generate_launch_description():
                           'R' :LaunchConfiguration('R'),
                           'P' :LaunchConfiguration('P'),
                           'Y' :LaunchConfiguration('Y'),
-                          'use_sim_time' : LaunchConfiguration('use_sim_time')
+                          'use_sim_time' : LaunchConfiguration('use_sim_time'),
                           }.items(),
     )
     
@@ -209,10 +230,10 @@ def generate_launch_description():
         set_use_sim_time,
         run_emulator_node,
         gazebo_connection_node,
-        robot_state_pub_node,
+        original_tf_nodes,
+        remapped_tf_nodes,
         robot_controller_spawner,
         joint_state_broadcaster_spawner,
-        delay_rviz_after_joint_state_broadcaster_spawner,
         included_launch_after_robot_controller_spawner,
         control_node,
     ]

--- a/dsr_bringup2/launch/dsr_bringup2_rviz.launch.py
+++ b/dsr_bringup2/launch/dsr_bringup2_rviz.launch.py
@@ -9,12 +9,12 @@
 import os
 
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler,DeclareLaunchArgument, TimerAction
+from launch.actions import RegisterEventHandler,DeclareLaunchArgument, TimerAction, GroupAction
 from launch.event_handlers import OnProcessExit
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration, PythonExpression
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetRemap
 from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
 from launch.actions import IncludeLaunchDescription
@@ -38,9 +38,10 @@ def generate_launch_description():
         DeclareLaunchArgument('mode',  default_value = 'virtual',   description = 'OPERATION MODE' ),
         DeclareLaunchArgument('model', default_value = 'm1013',     description = 'ROBOT_MODEL'    ),
         DeclareLaunchArgument('color', default_value = 'white',     description = 'ROBOT_COLOR'    ),
-        DeclareLaunchArgument('gui',   default_value = 'false',     description = 'Start RViz2'    ),
-        DeclareLaunchArgument('gz',    default_value = 'false',     description = 'USE GAZEBO SIM'    ),
+        DeclareLaunchArgument('gui',        default_value = 'false',     description = 'Start RViz2'    ),
+        DeclareLaunchArgument('gz',         default_value = 'false',     description = 'USE GAZEBO SIM'    ),
         DeclareLaunchArgument('rt_host',    default_value = '192.168.137.50',     description = 'ROBOT_RT_IP'    ),
+        DeclareLaunchArgument('remap_tf',   default_value = 'false',     description = 'REMAP TF'    )
     ]
     xacro_path = os.path.join( get_package_share_directory('dsr_description2'), 'xacro')
     # gui = LaunchConfiguration("gui")
@@ -141,6 +142,24 @@ def generate_launch_description():
         # condition=IfCondition(gui),
     )
 
+    original_tf_nodes = GroupAction(
+        actions=[
+            robot_state_pub_node,
+            rviz_node
+        ],
+        condition=UnlessCondition(LaunchConfiguration('remap_tf'))
+    )
+
+    remapped_tf_nodes = GroupAction(
+        actions=[
+            SetRemap(src='/tf', dst='tf'),
+            SetRemap(src='/tf_static', dst='tf_static'),
+            robot_state_pub_node,
+            rviz_node
+        ],
+        condition=IfCondition(LaunchConfiguration('remap_tf'))
+    )
+
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         namespace=LaunchConfiguration('name'),
@@ -181,10 +200,10 @@ def generate_launch_description():
     
     nodes = [
         run_emulator_node,
-        robot_state_pub_node,
+        original_tf_nodes,
+        remapped_tf_nodes,
         robot_controller_spawner,
         joint_state_broadcaster_spawner,
-        delay_rviz_after_joint_state_broadcaster_spawner,
         control_node,
     ]
 

--- a/dsr_bringup2/launch/dsr_bringup2_spawn_on_gazebo.launch.py
+++ b/dsr_bringup2/launch/dsr_bringup2_spawn_on_gazebo.launch.py
@@ -9,12 +9,12 @@
 import os
 
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler,DeclareLaunchArgument
+from launch.actions import RegisterEventHandler,DeclareLaunchArgument, GroupAction
 from launch.event_handlers import OnProcessExit
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration,PythonExpression
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetRemap
 from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
 from launch.actions import IncludeLaunchDescription
@@ -48,7 +48,7 @@ def generate_launch_description():
         DeclareLaunchArgument('Y',   default_value = '0',     description = 'Location Yaw on Gazebo'    ),
         DeclareLaunchArgument('rt_host',    default_value = '192.168.137.50',     description = 'ROBOT_RT_IP'    ),
         DeclareLaunchArgument('use_sim_time', default_value='true', description='Use simulation time'),
-        
+        DeclareLaunchArgument('remap_tf',   default_value = 'false',     description = 'REMAP TF'    ),
     ]
     set_use_sim_time = SetLaunchConfiguration(name='use_sim_time', value='true')
     
@@ -131,6 +131,7 @@ def generate_launch_description():
         parameters=[robot_description, robot_controllers],
         # output="both",
     )
+
     robot_state_pub_node = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
@@ -138,8 +139,9 @@ def generate_launch_description():
         namespace=LaunchConfiguration('name'),
         output='both',
         parameters=[{
-        'robot_description': Command(['xacro', ' ', xacro_path, '/', LaunchConfiguration('model'), '.urdf.xacro color:=', LaunchConfiguration('color')])           
-    }])
+            'robot_description': Command(['xacro', ' ', xacro_path, '/', LaunchConfiguration('model'), '.urdf.xacro color:=', LaunchConfiguration('color')])           
+        }],
+    )
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
@@ -149,19 +151,45 @@ def generate_launch_description():
         arguments=["-d", rviz_config_file],
         condition=IfCondition(gui),
     )
+    
+    robot_controller_spawner = Node(
+        package="controller_manager",
+        namespace=LaunchConfiguration('name'),
+        executable="spawner",
+        arguments=["dsr_controller2", "-c", "controller_manager"],
+    )
+    
+    # Delay rviz start after `joint_state_broadcaster`
+    delay_rviz_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=robot_controller_spawner,
+            on_exit=[rviz_node],
+        )
+    )
+
+    original_tf_nodes = GroupAction(
+        actions=[
+            robot_state_pub_node,
+            rviz_node
+        ],
+        condition=UnlessCondition(LaunchConfiguration('remap_tf'))
+    )
+
+    remapped_tf_nodes = GroupAction(
+        actions=[
+            SetRemap(src='/tf', dst='tf'),
+            SetRemap(src='/tf_static', dst='tf_static'),
+            robot_state_pub_node,
+            rviz_node
+        ],
+        condition=IfCondition(LaunchConfiguration('remap_tf'))
+    )
 
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         namespace=LaunchConfiguration('name'),
         executable="spawner",
         arguments=["joint_state_broadcaster", "-c", "controller_manager"],
-    )
-
-    robot_controller_spawner = Node(
-        package="controller_manager",
-        namespace=LaunchConfiguration('name'),
-        executable="spawner",
-        arguments=["dsr_controller2", "-c", "controller_manager"],
     )
 
     joint_trajectory_controller_spawner = Node(
@@ -172,13 +200,6 @@ def generate_launch_description():
     )
 
 
-    # Delay rviz start after `joint_state_broadcaster`
-    delay_rviz_after_joint_state_broadcaster_spawner = RegisterEventHandler(
-        event_handler=OnProcessExit(
-            target_action=robot_controller_spawner,
-            on_exit=[rviz_node],
-        )
-    )
 
     # Delay start of robot_controller after `joint_state_broadcaster`
     delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
@@ -210,7 +231,8 @@ def generate_launch_description():
                           'R' :LaunchConfiguration('R'),
                           'P' :LaunchConfiguration('P'),
                           'Y' :LaunchConfiguration('Y'),
-                          'use_sim_time' : LaunchConfiguration('use_sim_time')
+                          'use_sim_time' : LaunchConfiguration('use_sim_time'),
+                          'remap_tf' : LaunchConfiguration('remap_tf'),
                           }.items(),
     )
     
@@ -227,10 +249,10 @@ def generate_launch_description():
         set_use_sim_time,
         run_emulator_node,
         gazebo_connection_node,
-        robot_state_pub_node,
+        original_tf_nodes,
+        remapped_tf_nodes,
         robot_controller_spawner,
         joint_state_broadcaster_spawner,
-        delay_rviz_after_joint_state_broadcaster_spawner,
         included_launch_after_robot_controller_spawner,
         control_node,
     ]

--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -21,7 +21,7 @@
       dsr_position_controller:
         type: forward_command_controller/ForwardCommandController
 
-dsr_controller2:
+/**/dsr_controller2:
   ros__parameters:
     joints:
       - joint_1
@@ -31,7 +31,7 @@ dsr_controller2:
       - joint_5
       - joint_6
       
-dsr_position_controller:
+/**/dsr_position_controller:
   ros__parameters:
     joints:
       - joint_1
@@ -50,7 +50,7 @@ dsr_position_controller:
     #   - position
     #   - velocity
 
-dsr_joint_trajectory:
+/**/dsr_joint_trajectory:
   ros__parameters:
     joints:
       - joint_1
@@ -68,7 +68,7 @@ dsr_joint_trajectory:
       - position
       - velocity
 
-dsr_moveit_controller:
+/**/dsr_moveit_controller:
   ros__parameters:
     command_interfaces:
       - position

--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -21,66 +21,66 @@
       dsr_position_controller:
         type: forward_command_controller/ForwardCommandController
 
-/**/dsr_controller2:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-      
-/**/dsr_position_controller:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
-    interface_name: position
+  dsr_controller2:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
+        
+  dsr_position_controller:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
+      interface_name: position
 
-    # command_interfaces:
-    #   - position
-    #   - velocity
+      # command_interfaces:
+      #   - position
+      #   - velocity
 
-    # state_interfaces:
-    #   - position
-    #   - velocity
+      # state_interfaces:
+      #   - position
+      #   - velocity
 
-/**/dsr_joint_trajectory:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
+  dsr_joint_trajectory:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
 
-    command_interfaces:
-      - position
-      - velocity
+      command_interfaces:
+        - position
+        - velocity
 
-    state_interfaces:
-      - position
-      - velocity
+      state_interfaces:
+        - position
+        - velocity
 
-/**/dsr_moveit_controller:
-  ros__parameters:
-    command_interfaces:
-      - position
-      - velocity
-    state_interfaces:
-      - position
-      - velocity
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      - joint_4
-      - joint_5
-      - joint_6
+  dsr_moveit_controller:
+    ros__parameters:
+      command_interfaces:
+        - position
+        - velocity
+      state_interfaces:
+        - position
+        - velocity
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        - joint_4
+        - joint_5
+        - joint_6
 

--- a/dsr_controller2/config/dsr_controller2_p3020.yaml
+++ b/dsr_controller2/config/dsr_controller2_p3020.yaml
@@ -21,66 +21,66 @@
       dsr_position_controller:
         type: forward_command_controller/ForwardCommandController
 
-dsr_controller2:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      # - joint_4
-      - joint_5
-      - joint_6
-      
-dsr_position_controller:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      # - joint_4
-      - joint_5
-      - joint_6
-    interface_name: position
+  dsr_controller2:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        # - joint_4
+        - joint_5
+        - joint_6
+        
+  dsr_position_controller:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        # - joint_4
+        - joint_5
+        - joint_6
+      interface_name: position
 
-    # command_interfaces:
-    #   - position
-    #   - velocity
+      # command_interfaces:
+      #   - position
+      #   - velocity
 
-    # state_interfaces:
-    #   - position
-    #   - velocity
+      # state_interfaces:
+      #   - position
+      #   - velocity
 
-dsr_joint_trajectory:
-  ros__parameters:
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      # - joint_4
-      - joint_5
-      - joint_6
+  dsr_joint_trajectory:
+    ros__parameters:
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        # - joint_4
+        - joint_5
+        - joint_6
 
-    command_interfaces:
-      - position
-      - velocity
+      command_interfaces:
+        - position
+        - velocity
 
-    state_interfaces:
-      - position
-      - velocity
+      state_interfaces:
+        - position
+        - velocity
 
-dsr_moveit_controller:
-  ros__parameters:
-    command_interfaces:
-      - position
-      - velocity
-    state_interfaces:
-      - position
-      - velocity
-    joints:
-      - joint_1
-      - joint_2
-      - joint_3
-      # - joint_4
-      - joint_5
-      - joint_6
+  dsr_moveit_controller:
+    ros__parameters:
+      command_interfaces:
+        - position
+        - velocity
+      state_interfaces:
+        - position
+        - velocity
+      joints:
+        - joint_1
+        - joint_2
+        - joint_3
+        # - joint_4
+        - joint_5
+        - joint_6
 

--- a/dsr_gazebo2/launch/dsr_gazebo.launch.py
+++ b/dsr_gazebo2/launch/dsr_gazebo.launch.py
@@ -9,14 +9,14 @@
 import os
 
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler,DeclareLaunchArgument, IncludeLaunchDescription, TimerAction
+from launch.actions import RegisterEventHandler,DeclareLaunchArgument, IncludeLaunchDescription, TimerAction, GroupAction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.conditions import IfCondition, LaunchConfigurationEquals
+from launch.conditions import IfCondition, LaunchConfigurationEquals, UnlessCondition
 
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration, PythonExpression
 
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetRemap
 from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
 
@@ -35,7 +35,7 @@ ARGUMENTS =[
     DeclareLaunchArgument('P',   default_value = '0',     description = 'Location Pitch on Gazebo'    ),
     DeclareLaunchArgument('Y',   default_value = '0',     description = 'Location Yaw on Gazebo'    ),
     DeclareLaunchArgument('use_sim_time', default_value='true', description='Use simulation time'),
-
+    DeclareLaunchArgument('remap_tf',   default_value = 'false',     description = 'REMAP TF'    ),
 ]
 
 def generate_launch_description():
@@ -106,7 +106,6 @@ def generate_launch_description():
     rviz_config_file = PathJoinSubstitution(
         [FindPackageShare("dsr_description2"), "rviz", "default.rviz"]
     )
-    
 
     node_robot_state_publisher = Node(
         package="robot_state_publisher",
@@ -114,21 +113,6 @@ def generate_launch_description():
         namespace=PathJoinSubstitution([LaunchConfiguration('name'), "gz"]),
         output="screen",
         parameters=[robot_description],
-    )
-
-    joint_state_broadcaster_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        namespace=PathJoinSubstitution([LaunchConfiguration('name'), "gz"]),
-        arguments=["joint_state_broadcaster", "--controller-manager", "controller_manager"],
-    )
-        # condition=LaunchConfigurationEquals('use_sim_time', 'false')  
-    
-    dsr_position_controller_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        namespace=PathJoinSubstitution([LaunchConfiguration('name'), "gz"]),
-        arguments=["dsr_position_controller", "--controller-manager", "controller_manager"],
     )
     rviz_node = Node(
         package="rviz2",
@@ -139,6 +123,13 @@ def generate_launch_description():
         condition=IfCondition(gui),
     )
 
+    joint_state_broadcaster_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        namespace=PathJoinSubstitution([LaunchConfiguration('name'), "gz"]),
+        arguments=["joint_state_broadcaster", "--controller-manager", "controller_manager"],
+    )
+        # condition=LaunchConfigurationEquals('use_sim_time', 'false')  
     # Delay rviz start after `joint_state_broadcaster`
     delay_rviz_after_joint_state_broadcaster_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
@@ -146,6 +137,30 @@ def generate_launch_description():
             on_exit=[rviz_node],
         )
     )
+
+    original_tf_nodes = GroupAction(
+        actions=[
+            node_robot_state_publisher,
+        ],
+        condition=UnlessCondition(LaunchConfiguration('remap_tf'))
+    )
+
+    remapped_tf_nodes = GroupAction(
+        actions=[
+            SetRemap(src='/tf', dst='tf'),
+            SetRemap(src='/tf_static', dst='tf_static'),
+            node_robot_state_publisher,
+        ],
+        condition=IfCondition(LaunchConfiguration('remap_tf'))
+    )
+    
+    dsr_position_controller_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        namespace=PathJoinSubstitution([LaunchConfiguration('name'), "gz"]),
+        arguments=["dsr_position_controller", "--controller-manager", "controller_manager"],
+    )
+
 
     # launch issue position controller
     dsr_position_controller_spawner_action = TimerAction(
@@ -169,7 +184,8 @@ def generate_launch_description():
 
     nodes = [
         gazebo,
-        node_robot_state_publisher,
+        original_tf_nodes,
+        remapped_tf_nodes,
         gz_spawn_entity,
         dsr_position_controller_spawner_action,
         # delay_dsr_position_controller_spawner_after_joint_state_broadcaster_spawner

--- a/dsr_gazebo2/launch/dsr_spawn_on_gazebo.launch.py
+++ b/dsr_gazebo2/launch/dsr_spawn_on_gazebo.launch.py
@@ -9,14 +9,14 @@
 import os
 
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler,DeclareLaunchArgument, IncludeLaunchDescription, TimerAction
+from launch.actions import RegisterEventHandler,DeclareLaunchArgument, IncludeLaunchDescription, TimerAction, GroupAction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.conditions import IfCondition, LaunchConfigurationEquals
+from launch.conditions import IfCondition, LaunchConfigurationEquals, UnlessCondition
 
 from launch.event_handlers import OnProcessExit
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
 
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetRemap
 from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
 
@@ -35,7 +35,7 @@ ARGUMENTS =[
     DeclareLaunchArgument('P',   default_value = '0',     description = 'Location Pitch on Gazebo'    ),
     DeclareLaunchArgument('Y',   default_value = '0',     description = 'Location Yaw on Gazebo'    ),
     DeclareLaunchArgument('use_sim_time', default_value='true', description='Use simulation time'),
-
+    DeclareLaunchArgument('remap_tf',   default_value = 'false',     description = 'REMAP TF'    ),
 ]
 
 def generate_launch_description():
@@ -106,7 +106,7 @@ def generate_launch_description():
     rviz_config_file = PathJoinSubstitution(
         [FindPackageShare("dsr_description2"), "rviz", "default.rviz"]
     )
-    
+
 
     node_robot_state_publisher = Node(
         package="robot_state_publisher",
@@ -114,6 +114,22 @@ def generate_launch_description():
         namespace=PathJoinSubstitution([LaunchConfiguration('name'), "gz"]),
         output="screen",
         parameters=[robot_description],
+    )
+
+    original_tf_nodes = GroupAction(
+        actions=[
+            node_robot_state_publisher,
+        ],
+        condition=UnlessCondition(LaunchConfiguration('remap_tf'))
+    )
+
+    remapped_tf_nodes = GroupAction(
+        actions=[
+            SetRemap(src='/tf', dst='tf'),
+            SetRemap(src='/tf_static', dst='tf_static'),
+            node_robot_state_publisher,
+        ],
+        condition=IfCondition(LaunchConfiguration('remap_tf'))
     )
 
     joint_state_broadcaster_spawner = Node(
@@ -170,7 +186,8 @@ def generate_launch_description():
 
     nodes = [
         # gazebo,
-        node_robot_state_publisher,
+        original_tf_nodes,
+        remapped_tf_nodes,
         gz_spawn_entity,
         dsr_position_controller_spawner_action,
         # delay_dsr_position_controller_spawner_after_joint_state_broadcaster_spawner


### PR DESCRIPTION
Adds a new launch option `remap_tf` to gazebo and rviz launch files. This allows launching multiple robots and multiple RViz instances, without having both robots using the same tf topic.

I also cherry-picked the changes from #209.