### PR TITLE
Add real-time data publishing feature (rt_data topics) to dsr_controller2

### DIFF
--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -31,12 +31,11 @@
         - joint_5
         - joint_6
 
-      # [modified]  
+      # rt_data topic argument
       use_rt_topic_pub: false
-      rt_timer_ms: 10                      # 주기(ms)
-      rt_topic_keys:                       # 발행할 필드 이름 -> dsr_controller2.hpp -> extract_filed 함수 참고
+      rt_timer_ms: 10                      # ms
+      rt_topic_keys:                       # Field names available for RT publishing (see extract_field() in dsr_controller2.cpp)
         - actual_joint_position
-
 
   dsr_position_controller:
     ros__parameters:

--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -30,7 +30,10 @@
         - joint_4
         - joint_5
         - joint_6
-        
+      use_rt_data_pub: true          # true면 타이머로 주기적으로 read_data_rt 호출해서 토픽 발행
+      tcp_force_frame_id: tool0      # WrenchStamped.header.frame_id
+      rt_timer_ms: 5                 # read_data_rt 호출 주기(ms). 5~10 권장
+
   dsr_position_controller:
     ros__parameters:
       joints:

--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -32,12 +32,11 @@
         - joint_6
 
       # [modified]  
-      use_rt_topic_pub: true
-      rt_topic_ns: "read_data_rt"          # 토픽 네임스페이스 (결과: ~/read_data_rt/<key>)
+      use_rt_topic_pub: false
       rt_timer_ms: 10                      # 주기(ms)
-      rt_topic_keys:                       # 발행할 필드 이름(원하는 것만 선택)
+      rt_topic_keys:                       # 발행할 필드 이름 -> dsr_controller2.hpp -> extract_filed 함수 참고
         - actual_joint_position
-        - external_tcp_force
+
 
   dsr_position_controller:
     ros__parameters:

--- a/dsr_controller2/config/dsr_controller2.yaml
+++ b/dsr_controller2/config/dsr_controller2.yaml
@@ -30,9 +30,14 @@
         - joint_4
         - joint_5
         - joint_6
-      use_rt_data_pub: true          # true면 타이머로 주기적으로 read_data_rt 호출해서 토픽 발행
-      tcp_force_frame_id: tool0      # WrenchStamped.header.frame_id
-      rt_timer_ms: 5                 # read_data_rt 호출 주기(ms). 5~10 권장
+
+      # [modified]  
+      use_rt_topic_pub: true
+      rt_topic_ns: "read_data_rt"          # 토픽 네임스페이스 (결과: ~/read_data_rt/<key>)
+      rt_timer_ms: 10                      # 주기(ms)
+      rt_topic_keys:                       # 발행할 필드 이름(원하는 것만 선택)
+        - actual_joint_position
+        - external_tcp_force
 
   dsr_position_controller:
     ros__parameters:

--- a/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
+++ b/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
@@ -200,7 +200,9 @@
 #include "dsr_msgs2/srv/stop_rt_control.hpp"
 #include "dsr_msgs2/srv/write_data_rt.hpp"
 
-#include <geometry_msgs/msg/wrench_stamped.hpp> //[modified]
+// #include <geometry_msgs/msg/wrench_stamped.hpp> //[modified]
+#include "std_msgs/msg/float32_multi_array.hpp" // [modified]
+
 
 #include "../../../dsr_common2/include/DRFLEx.h"
 
@@ -719,27 +721,58 @@ protected:
   rclcpp::Service<dsr_msgs2::srv::ReadDataRt>::SharedPtr                    m_nh_read_data_rt;
   rclcpp::Service<dsr_msgs2::srv::WriteDataRt>::SharedPtr                   m_nh_write_data_rt;
 
+//   // [modified]
+//   // --- read_data_rt 기반 토픽 발행 제어 파라미터
+//   bool use_rt_data_pub_{false};
+
+//   // --- TCP Force frame_id 파라미터 (기본값 예: tool0)
+//   std::string tcp_force_frame_id_{"tool0"};
+
+//   // --- 퍼블리셔 & 타이머
+//   rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>::SharedPtr tcp_force_pub_;
+//   rclcpp::TimerBase::SharedPtr rt_timer_;
+
+//   // --- 주기적으로 read_data_rt() 호출해 발행하는 멤버 함수 선언
+//   void publishRtData();
+
+// // [modified]
+// private:
+//   static constexpr const char* PARAM_USE_RT_DATA_PUB     = "use_rt_data_pub";
+//   static constexpr const char* PARAM_TCP_FORCE_FRAME_ID  = "tcp_force_frame_id";
+//   static constexpr const char* PARAM_RT_TIMER_MS         = "rt_timer_ms";
+
   // [modified]
-  // --- read_data_rt 기반 토픽 발행 제어 파라미터
-  bool use_rt_data_pub_{false};
+    // [추가] read_data_rt 기반 토픽 발행 on/off
+  bool use_rt_topic_pub_{false};
 
-  // --- TCP Force frame_id 파라미터 (기본값 예: tool0)
-  std::string tcp_force_frame_id_{"tool0"};
+  // [추가] 발행할 키 목록
+  std::vector<std::string> rt_topic_keys_;
 
-  // --- 퍼블리셔 & 타이머
-  rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>::SharedPtr tcp_force_pub_;
+  // [추가] 토픽 네임스페이스 (기본: "read_data_rt")
+  std::string rt_topic_ns_{"read_data_rt"};
+
+  // [추가] 키별 퍼블리셔 (Float32MultiArray로 raw 값 그대로)
+  std::unordered_map<std::string,
+      rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr> rt_pub_map_;
+
+  // [추가] 주기 타이머
   rclcpp::TimerBase::SharedPtr rt_timer_;
 
-  // --- 주기적으로 read_data_rt() 호출해 발행하는 멤버 함수 선언
-  void publishRtData();
+  // [추가] 주기 퍼블리시 함수
+  void publish_read_data_rt_selected();
 
-// [modified]
+  // [추가] 필드 추출 유틸
+  static bool extract_field(LPRT_OUTPUT_DATA_LIST temp,
+                            const std::string& key,
+                            std::vector<float>& out);
+
 private:
-  static constexpr const char* PARAM_USE_RT_DATA_PUB     = "use_rt_data_pub";
-  static constexpr const char* PARAM_TCP_FORCE_FRAME_ID  = "tcp_force_frame_id";
-  static constexpr const char* PARAM_RT_TIMER_MS         = "rt_timer_ms";
+  // [추가] 파라미터 키 상수
+  static constexpr const char* PARAM_USE_RT_TOPIC_PUB = "use_rt_topic_pub";
+  static constexpr const char* PARAM_RT_TOPIC_KEYS    = "rt_topic_keys";
+  static constexpr const char* PARAM_RT_TOPIC_NS      = "rt_topic_ns";
+  static constexpr const char* PARAM_RT_TIMER_MS      = "rt_timer_ms";
 };
-
 }  // namespace dsr_controller2
 
 #endif  

--- a/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
+++ b/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
@@ -721,56 +721,18 @@ protected:
   rclcpp::Service<dsr_msgs2::srv::ReadDataRt>::SharedPtr                    m_nh_read_data_rt;
   rclcpp::Service<dsr_msgs2::srv::WriteDataRt>::SharedPtr                   m_nh_write_data_rt;
 
-//   // [modified]
-//   // --- read_data_rt 기반 토픽 발행 제어 파라미터
-//   bool use_rt_data_pub_{false};
-
-//   // --- TCP Force frame_id 파라미터 (기본값 예: tool0)
-//   std::string tcp_force_frame_id_{"tool0"};
-
-//   // --- 퍼블리셔 & 타이머
-//   rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>::SharedPtr tcp_force_pub_;
-//   rclcpp::TimerBase::SharedPtr rt_timer_;
-
-//   // --- 주기적으로 read_data_rt() 호출해 발행하는 멤버 함수 선언
-//   void publishRtData();
-
-// // [modified]
-// private:
-//   static constexpr const char* PARAM_USE_RT_DATA_PUB     = "use_rt_data_pub";
-//   static constexpr const char* PARAM_TCP_FORCE_FRAME_ID  = "tcp_force_frame_id";
-//   static constexpr const char* PARAM_RT_TIMER_MS         = "rt_timer_ms";
 
   // [modified]
-    // [추가] read_data_rt 기반 토픽 발행 on/off
   bool use_rt_topic_pub_{false};
-
-  // [추가] 발행할 키 목록
   std::vector<std::string> rt_topic_keys_;
-
-  // [추가] 토픽 네임스페이스 (기본: "read_data_rt")
-  std::string rt_topic_ns_{"read_data_rt"};
-
-  // [추가] 키별 퍼블리셔 (Float32MultiArray로 raw 값 그대로)
-  std::unordered_map<std::string,
-      rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr> rt_pub_map_;
-
-  // [추가] 주기 타이머
+  std::unordered_map<std::string,rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr> rt_pub_map_;
   rclcpp::TimerBase::SharedPtr rt_timer_;
-
-  // [추가] 주기 퍼블리시 함수
   void publish_read_data_rt_selected();
-
-  // [추가] 필드 추출 유틸
-  static bool extract_field(LPRT_OUTPUT_DATA_LIST temp,
-                            const std::string& key,
-                            std::vector<float>& out);
+  static bool extract_field(LPRT_OUTPUT_DATA_LIST temp,const std::string& key,std::vector<float>& out);
 
 private:
-  // [추가] 파라미터 키 상수
   static constexpr const char* PARAM_USE_RT_TOPIC_PUB = "use_rt_topic_pub";
   static constexpr const char* PARAM_RT_TOPIC_KEYS    = "rt_topic_keys";
-  static constexpr const char* PARAM_RT_TOPIC_NS      = "rt_topic_ns";
   static constexpr const char* PARAM_RT_TIMER_MS      = "rt_timer_ms";
 };
 }  // namespace dsr_controller2

--- a/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
+++ b/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
@@ -200,8 +200,7 @@
 #include "dsr_msgs2/srv/stop_rt_control.hpp"
 #include "dsr_msgs2/srv/write_data_rt.hpp"
 
-// #include <geometry_msgs/msg/wrench_stamped.hpp> //[modified]
-#include "std_msgs/msg/float32_multi_array.hpp" // [modified]
+#include "std_msgs/msg/float32_multi_array.hpp"
 
 
 #include "../../../dsr_common2/include/DRFLEx.h"
@@ -505,7 +504,6 @@ namespace DRFL_CALLBACKS {
   void OnMonitoringStateCB(const ROBOT_STATE eState);
   void OnMonitoringAccessControlCB(const MONITORING_ACCESS_CONTROL eAccCtrl);
   void OnLogAlarm(LPLOG_ALARM pLogAlarm);
-  // void OnMonitoringDataExCB(const LPMONITORING_DATA_EX pData); # [modified]
   void OnDisConnected();
 }
 
@@ -721,8 +719,7 @@ protected:
   rclcpp::Service<dsr_msgs2::srv::ReadDataRt>::SharedPtr                    m_nh_read_data_rt;
   rclcpp::Service<dsr_msgs2::srv::WriteDataRt>::SharedPtr                   m_nh_write_data_rt;
 
-
-  // [modified]
+  // Real-time data publishing members and parameters for periodic Float32MultiArray topic output.
   bool use_rt_topic_pub_{false};
   std::vector<std::string> rt_topic_keys_;
   std::unordered_map<std::string,rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr> rt_pub_map_;

--- a/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
+++ b/dsr_controller2/include/dsr_controller2/dsr_controller2.hpp
@@ -200,6 +200,8 @@
 #include "dsr_msgs2/srv/stop_rt_control.hpp"
 #include "dsr_msgs2/srv/write_data_rt.hpp"
 
+#include <geometry_msgs/msg/wrench_stamped.hpp> //[modified]
+
 #include "../../../dsr_common2/include/DRFLEx.h"
 
 #define _DEBUG_DSR_CTL      0
@@ -501,7 +503,7 @@ namespace DRFL_CALLBACKS {
   void OnMonitoringStateCB(const ROBOT_STATE eState);
   void OnMonitoringAccessControlCB(const MONITORING_ACCESS_CONTROL eAccCtrl);
   void OnLogAlarm(LPLOG_ALARM pLogAlarm);
-  void OnMonitoringDataExCB(const LPMONITORING_DATA_EX pData);
+  // void OnMonitoringDataExCB(const LPMONITORING_DATA_EX pData); # [modified]
   void OnDisConnected();
 }
 
@@ -717,8 +719,27 @@ protected:
   rclcpp::Service<dsr_msgs2::srv::ReadDataRt>::SharedPtr                    m_nh_read_data_rt;
   rclcpp::Service<dsr_msgs2::srv::WriteDataRt>::SharedPtr                   m_nh_write_data_rt;
 
+  // [modified]
+  // --- read_data_rt 기반 토픽 발행 제어 파라미터
+  bool use_rt_data_pub_{false};
+
+  // --- TCP Force frame_id 파라미터 (기본값 예: tool0)
+  std::string tcp_force_frame_id_{"tool0"};
+
+  // --- 퍼블리셔 & 타이머
+  rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>::SharedPtr tcp_force_pub_;
+  rclcpp::TimerBase::SharedPtr rt_timer_;
+
+  // --- 주기적으로 read_data_rt() 호출해 발행하는 멤버 함수 선언
+  void publishRtData();
+
+// [modified]
+private:
+  static constexpr const char* PARAM_USE_RT_DATA_PUB     = "use_rt_data_pub";
+  static constexpr const char* PARAM_TCP_FORCE_FRAME_ID  = "tcp_force_frame_id";
+  static constexpr const char* PARAM_RT_TIMER_MS         = "rt_timer_ms";
 };
 
-}  // namespace dsr_control2
+}  // namespace dsr_controller2
 
 #endif  

--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -77,7 +77,6 @@ controller_interface::CallbackReturn RobotController::on_init()
     instance = this;
     m_model = g_model;
 
-    // [modified]
     use_rt_topic_pub_ = auto_declare<bool>(PARAM_USE_RT_TOPIC_PUB, false);
     auto rt_ms        = auto_declare<int>(PARAM_RT_TIMER_MS, 10);
 
@@ -116,7 +115,7 @@ controller_interface::CallbackReturn RobotController::on_configure(const rclcpp_
 	Drfl->set_on_disconnected(DRFL_CALLBACKS::OnDisConnected);
 	Drfl->set_on_monitoring_data_ex(DRFL_CALLBACKS::OnMonitoringDataExCB);
 
-    // [modified] : create publishers by key
+    // create publishers by key
     if (use_rt_topic_pub_) {
         rt_pub_map_.clear();
         for (const auto& key : rt_topic_keys_) 
@@ -133,7 +132,7 @@ controller_interface::CallbackReturn RobotController::on_configure(const rclcpp_
   return CallbackReturn::SUCCESS;
 }
 
-//[modified]
+// Publishes selected real-time robot data fields as Float32MultiArray messages.
 void RobotController::publish_read_data_rt_selected() {
   LPRT_OUTPUT_DATA_LIST temp = Drfl->read_data_rt();
   if (!temp) {
@@ -157,7 +156,7 @@ void RobotController::publish_read_data_rt_selected() {
   }
 }
 
-// [modified] : Extracts a specific field from the real-time data structure (LPRT_OUTPUT_DATA_LIST)
+// Extracts a specific field from the real-time data structure (LPRT_OUTPUT_DATA_LIST)
 bool RobotController::extract_field(LPRT_OUTPUT_DATA_LIST temp, const std::string& key, std::vector<float>& out)
 {
     out.clear();

--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -77,9 +77,21 @@ controller_interface::CallbackReturn RobotController::on_init()
     instance = this;
     m_model = g_model;
     // [modified]
-    use_rt_data_pub_    = auto_declare<bool>(PARAM_USE_RT_DATA_PUB, false);
-    tcp_force_frame_id_ = auto_declare<std::string>(PARAM_TCP_FORCE_FRAME_ID, "tool0");
-    const auto rt_ms    = auto_declare<int>(PARAM_RT_TIMER_MS, 5);
+    // use_rt_data_pub_    = auto_declare<bool>(PARAM_USE_RT_DATA_PUB, false);
+    // tcp_force_frame_id_ = auto_declare<std::string>(PARAM_TCP_FORCE_FRAME_ID, "tool0");
+    // const auto rt_ms    = auto_declare<int>(PARAM_RT_TIMER_MS, 5);
+
+    use_rt_topic_pub_ = auto_declare<bool>(PARAM_USE_RT_TOPIC_PUB, false);
+    rt_topic_ns_      = auto_declare<std::string>(PARAM_RT_TOPIC_NS, "read_data_rt");
+    auto rt_ms        = auto_declare<int>(PARAM_RT_TIMER_MS, 10);
+
+    // 문자열 배열 파라미터 선언
+    if (!get_node()->has_parameter(PARAM_RT_TOPIC_KEYS)) {
+        get_node()->declare_parameter<std::vector<std::string>>(PARAM_RT_TOPIC_KEYS,
+                                                                std::vector<std::string>{});
+    }
+    rt_topic_keys_ = get_node()->get_parameter(PARAM_RT_TOPIC_KEYS).as_string_array();
+
   return CallbackReturn::SUCCESS;
 }
 
@@ -112,43 +124,122 @@ controller_interface::CallbackReturn RobotController::on_configure(const rclcpp_
 	Drfl->set_on_disconnected(DRFL_CALLBACKS::OnDisConnected);
 	Drfl->set_on_monitoring_data_ex(DRFL_CALLBACKS::OnMonitoringDataExCB);
 
-    tcp_force_pub_ = get_node()->create_publisher<geometry_msgs::msg::WrenchStamped>(
-    "~/tcp_force", rclcpp::SensorDataQoS());
+    // [modified]
+    // 선택 토픽 발행 설정
+    if (use_rt_topic_pub_) {
+        // 키별 퍼블리셔 준비
+        rt_pub_map_.clear();
+        for (const auto& key : rt_topic_keys_) {
+        // 토픽명: "~/<rt_topic_ns_>/<key>"  예) ~/read_data_rt/external_tcp_force
+        auto topic = std::string("~/") + rt_topic_ns_ + "/" + key;
+        rt_pub_map_[key] = get_node()->create_publisher<std_msgs::msg::Float32MultiArray>(
+            topic, rclcpp::SystemDefaultsQoS());
+        }
 
-    if (use_rt_data_pub_) {
-    auto period = std::chrono::milliseconds(get_node()->get_parameter(PARAM_RT_TIMER_MS).as_int());
-    rt_timer_ = get_node()->create_wall_timer(period, [this]{ publishRtData(); });
+        // 타이머 (주기 ms)
+        const int rt_ms = get_node()->get_parameter(PARAM_RT_TIMER_MS).as_int();
+        rt_timer_ = get_node()->create_wall_timer(
+            std::chrono::milliseconds(rt_ms),
+            std::bind(&RobotController::publish_read_data_rt_selected, this));
     }
 
   return CallbackReturn::SUCCESS;
 }
 
-// [modified]
-void RobotController::publishRtData()
-{
-  if (!use_rt_data_pub_) return;
+// // [modified]
+// void RobotController::publishRtData()
+// {
+//   if (!use_rt_data_pub_) return;
 
+//   LPRT_OUTPUT_DATA_LIST temp = Drfl->read_data_rt();
+//   if (temp == nullptr) {
+//     RCLCPP_WARN(get_node()->get_logger(), "read_data_rt() returned nullptr");
+//     return;
+//   }
+
+//   geometry_msgs::msg::WrenchStamped msg;
+//   msg.header.stamp = get_node()->now();
+//   msg.header.frame_id = tcp_force_frame_id_;
+
+//   // external_tcp_force 는 길이 6짜리 배열 (Fx, Fy, Fz, Tx, Ty, Tz)
+//   msg.wrench.force.x  = temp->external_tcp_force[0];
+//   msg.wrench.force.y  = temp->external_tcp_force[1];
+//   msg.wrench.force.z  = temp->external_tcp_force[2];
+//   msg.wrench.torque.x = temp->external_tcp_force[3];
+//   msg.wrench.torque.y = temp->external_tcp_force[4];
+//   msg.wrench.torque.z = temp->external_tcp_force[5];
+
+//   tcp_force_pub_->publish(msg);
+// }
+
+//[modified]
+void RobotController::publish_read_data_rt_selected() {
+  // read_data_rt() 로 raw 포인터 획득
   LPRT_OUTPUT_DATA_LIST temp = Drfl->read_data_rt();
-  if (temp == nullptr) {
-    RCLCPP_WARN(get_node()->get_logger(), "read_data_rt() returned nullptr");
+  if (!temp) {
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(),
+                         2000, "read_data_rt() returned nullptr");
     return;
   }
 
-  geometry_msgs::msg::WrenchStamped msg;
-  msg.header.stamp = get_node()->now();
-  msg.header.frame_id = tcp_force_frame_id_;
+  // 각 key마다 추출 → Float32MultiArray 발행
+  for (const auto& key : rt_topic_keys_) {
+    auto it = rt_pub_map_.find(key);
+    if (it == rt_pub_map_.end()) continue;
 
-  // external_tcp_force 는 길이 6짜리 배열 (Fx, Fy, Fz, Tx, Ty, Tz)
-  msg.wrench.force.x  = temp->external_tcp_force[0];
-  msg.wrench.force.y  = temp->external_tcp_force[1];
-  msg.wrench.force.z  = temp->external_tcp_force[2];
-  msg.wrench.torque.x = temp->external_tcp_force[3];
-  msg.wrench.torque.y = temp->external_tcp_force[4];
-  msg.wrench.torque.z = temp->external_tcp_force[5];
+    std::vector<float> vals;
+    if (!extract_field(temp, key, vals)) {
+      // 지원하지 않는 키면 경고(과도한 로그 방지하려면 throttle)
+      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(),
+                           5000, "read_data_rt(): unsupported key '%s'", key.c_str());
+      continue;
+    }
 
-  tcp_force_pub_->publish(msg);
+    std_msgs::msg::Float32MultiArray msg;
+    msg.data = std::move(vals); // raw값 그대로
+    it->second->publish(msg);
+  }
 }
 
+// [modified]
+bool RobotController::extract_field(LPRT_OUTPUT_DATA_LIST temp,
+                                    const std::string& key,
+                                    std::vector<float>& out) {
+  // 필요한 필드만 우선 지원 (요청 확장 시 여기에 추가)
+  // 모든 항목은 raw float 배열 그대로 복사
+  auto copy_arr = [&](const float* src, size_t n) {
+    out.assign(src, src + n);
+    return true;
+  };
+
+  if (key == "actual_joint_position")        return copy_arr(temp->actual_joint_position,        6);
+  if (key == "actual_joint_position_abs")    return copy_arr(temp->actual_joint_position_abs,    6);
+  if (key == "actual_joint_velocity")        return copy_arr(temp->actual_joint_velocity,        6);
+  if (key == "actual_joint_velocity_abs")    return copy_arr(temp->actual_joint_velocity_abs,    6);
+  if (key == "actual_tcp_position")          return copy_arr(temp->actual_tcp_position,          6);
+  if (key == "actual_tcp_velocity")          return copy_arr(temp->actual_tcp_velocity,          6);
+  if (key == "actual_flange_position")       return copy_arr(temp->actual_flange_position,       6);
+  if (key == "actual_flange_velocity")       return copy_arr(temp->actual_flange_velocity,       6);
+  if (key == "actual_motor_torque")          return copy_arr(temp->actual_motor_torque,          6);
+  if (key == "actual_joint_torque")          return copy_arr(temp->actual_joint_torque,          6);
+  if (key == "raw_joint_torque")             return copy_arr(temp->raw_joint_torque,             6);
+  if (key == "raw_force_torque")             return copy_arr(temp->raw_force_torque,             6);
+  if (key == "external_joint_torque")        return copy_arr(temp->external_joint_torque,        6);
+  if (key == "external_tcp_force")           return copy_arr(temp->external_tcp_force,           6);
+  if (key == "target_joint_position")        return copy_arr(temp->target_joint_position,        6);
+  if (key == "target_joint_velocity")        return copy_arr(temp->target_joint_velocity,        6);
+  if (key == "target_joint_acceleration")    return copy_arr(temp->target_joint_acceleration,    6);
+  if (key == "target_motor_torque")          return copy_arr(temp->target_motor_torque,          6);
+  if (key == "target_tcp_position")          return copy_arr(temp->target_tcp_position,          6);
+  if (key == "target_tcp_velocity")          return copy_arr(temp->target_tcp_velocity,          6);
+  if (key == "gravity_torque")               return copy_arr(temp->gravity_torque,               6);
+  if (key == "joint_temperature")            return copy_arr(temp->joint_temperature,            6);
+  if (key == "goal_joint_position")          return copy_arr(temp->goal_joint_position,          6);
+  if (key == "goal_tcp_position")            return copy_arr(temp->goal_tcp_position,            6);
+
+  // 필요 시 단일/기타 필드(예: time_stamp)는 별도 토픽으로 Float64 등으로 확장 가능
+  return false;
+}
 
 
 

--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -76,6 +76,10 @@ controller_interface::CallbackReturn RobotController::on_init()
 {
     instance = this;
     m_model = g_model;
+    // [modified]
+    use_rt_data_pub_    = auto_declare<bool>(PARAM_USE_RT_DATA_PUB, false);
+    tcp_force_frame_id_ = auto_declare<std::string>(PARAM_TCP_FORCE_FRAME_ID, "tool0");
+    const auto rt_ms    = auto_declare<int>(PARAM_RT_TIMER_MS, 5);
   return CallbackReturn::SUCCESS;
 }
 
@@ -108,8 +112,45 @@ controller_interface::CallbackReturn RobotController::on_configure(const rclcpp_
 	Drfl->set_on_disconnected(DRFL_CALLBACKS::OnDisConnected);
 	Drfl->set_on_monitoring_data_ex(DRFL_CALLBACKS::OnMonitoringDataExCB);
 
+    tcp_force_pub_ = get_node()->create_publisher<geometry_msgs::msg::WrenchStamped>(
+    "~/tcp_force", rclcpp::SensorDataQoS());
+
+    if (use_rt_data_pub_) {
+    auto period = std::chrono::milliseconds(get_node()->get_parameter(PARAM_RT_TIMER_MS).as_int());
+    rt_timer_ = get_node()->create_wall_timer(period, [this]{ publishRtData(); });
+    }
+
   return CallbackReturn::SUCCESS;
 }
+
+// [modified]
+void RobotController::publishRtData()
+{
+  if (!use_rt_data_pub_) return;
+
+  LPRT_OUTPUT_DATA_LIST temp = Drfl->read_data_rt();
+  if (temp == nullptr) {
+    RCLCPP_WARN(get_node()->get_logger(), "read_data_rt() returned nullptr");
+    return;
+  }
+
+  geometry_msgs::msg::WrenchStamped msg;
+  msg.header.stamp = get_node()->now();
+  msg.header.frame_id = tcp_force_frame_id_;
+
+  // external_tcp_force 는 길이 6짜리 배열 (Fx, Fy, Fz, Tx, Ty, Tz)
+  msg.wrench.force.x  = temp->external_tcp_force[0];
+  msg.wrench.force.y  = temp->external_tcp_force[1];
+  msg.wrench.force.z  = temp->external_tcp_force[2];
+  msg.wrench.torque.x = temp->external_tcp_force[3];
+  msg.wrench.torque.y = temp->external_tcp_force[4];
+  msg.wrench.torque.z = temp->external_tcp_force[5];
+
+  tcp_force_pub_->publish(msg);
+}
+
+
+
 
 void check_dsr_model(std::array<float, NUM_JOINT>& target_joint){
     if (m_model == "p3020"){

--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -76,20 +76,12 @@ controller_interface::CallbackReturn RobotController::on_init()
 {
     instance = this;
     m_model = g_model;
-    // [modified]
-    // use_rt_data_pub_    = auto_declare<bool>(PARAM_USE_RT_DATA_PUB, false);
-    // tcp_force_frame_id_ = auto_declare<std::string>(PARAM_TCP_FORCE_FRAME_ID, "tool0");
-    // const auto rt_ms    = auto_declare<int>(PARAM_RT_TIMER_MS, 5);
 
+    // [modified]
     use_rt_topic_pub_ = auto_declare<bool>(PARAM_USE_RT_TOPIC_PUB, false);
-    rt_topic_ns_      = auto_declare<std::string>(PARAM_RT_TOPIC_NS, "read_data_rt");
     auto rt_ms        = auto_declare<int>(PARAM_RT_TIMER_MS, 10);
 
-    // 문자열 배열 파라미터 선언
-    if (!get_node()->has_parameter(PARAM_RT_TOPIC_KEYS)) {
-        get_node()->declare_parameter<std::vector<std::string>>(PARAM_RT_TOPIC_KEYS,
-                                                                std::vector<std::string>{});
-    }
+    if (!get_node()->has_parameter(PARAM_RT_TOPIC_KEYS)) {get_node()->declare_parameter<std::vector<std::string>>(PARAM_RT_TOPIC_KEYS,std::vector<std::string>{});}
     rt_topic_keys_ = get_node()->get_parameter(PARAM_RT_TOPIC_KEYS).as_string_array();
 
   return CallbackReturn::SUCCESS;
@@ -124,124 +116,169 @@ controller_interface::CallbackReturn RobotController::on_configure(const rclcpp_
 	Drfl->set_on_disconnected(DRFL_CALLBACKS::OnDisConnected);
 	Drfl->set_on_monitoring_data_ex(DRFL_CALLBACKS::OnMonitoringDataExCB);
 
-    // [modified]
-    // 선택 토픽 발행 설정
+    // [modified] : create publishers by key
     if (use_rt_topic_pub_) {
-        // 키별 퍼블리셔 준비
         rt_pub_map_.clear();
-        for (const auto& key : rt_topic_keys_) {
-        // 토픽명: "~/<rt_topic_ns_>/<key>"  예) ~/read_data_rt/external_tcp_force
-        auto topic = std::string("~/") + rt_topic_ns_ + "/" + key;
-        rt_pub_map_[key] = get_node()->create_publisher<std_msgs::msg::Float32MultiArray>(
-            topic, rclcpp::SystemDefaultsQoS());
+        for (const auto& key : rt_topic_keys_) 
+        {
+        auto topic = "/rt_topic/" + key; // topic name
+        rt_pub_map_[key] = get_node()->create_publisher<std_msgs::msg::Float32MultiArray>(topic, rclcpp::SystemDefaultsQoS());
         }
 
-        // 타이머 (주기 ms)
+        // timer
         const int rt_ms = get_node()->get_parameter(PARAM_RT_TIMER_MS).as_int();
-        rt_timer_ = get_node()->create_wall_timer(
-            std::chrono::milliseconds(rt_ms),
-            std::bind(&RobotController::publish_read_data_rt_selected, this));
+        rt_timer_ = get_node()->create_wall_timer(std::chrono::milliseconds(rt_ms),std::bind(&RobotController::publish_read_data_rt_selected, this));
     }
 
   return CallbackReturn::SUCCESS;
 }
 
-// // [modified]
-// void RobotController::publishRtData()
-// {
-//   if (!use_rt_data_pub_) return;
-
-//   LPRT_OUTPUT_DATA_LIST temp = Drfl->read_data_rt();
-//   if (temp == nullptr) {
-//     RCLCPP_WARN(get_node()->get_logger(), "read_data_rt() returned nullptr");
-//     return;
-//   }
-
-//   geometry_msgs::msg::WrenchStamped msg;
-//   msg.header.stamp = get_node()->now();
-//   msg.header.frame_id = tcp_force_frame_id_;
-
-//   // external_tcp_force 는 길이 6짜리 배열 (Fx, Fy, Fz, Tx, Ty, Tz)
-//   msg.wrench.force.x  = temp->external_tcp_force[0];
-//   msg.wrench.force.y  = temp->external_tcp_force[1];
-//   msg.wrench.force.z  = temp->external_tcp_force[2];
-//   msg.wrench.torque.x = temp->external_tcp_force[3];
-//   msg.wrench.torque.y = temp->external_tcp_force[4];
-//   msg.wrench.torque.z = temp->external_tcp_force[5];
-
-//   tcp_force_pub_->publish(msg);
-// }
-
 //[modified]
 void RobotController::publish_read_data_rt_selected() {
-  // read_data_rt() 로 raw 포인터 획득
   LPRT_OUTPUT_DATA_LIST temp = Drfl->read_data_rt();
   if (!temp) {
-    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(),
-                         2000, "read_data_rt() returned nullptr");
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 2000, "read_data_rt() returned nullptr");
     return;
   }
 
-  // 각 key마다 추출 → Float32MultiArray 발행
   for (const auto& key : rt_topic_keys_) {
     auto it = rt_pub_map_.find(key);
     if (it == rt_pub_map_.end()) continue;
 
     std::vector<float> vals;
     if (!extract_field(temp, key, vals)) {
-      // 지원하지 않는 키면 경고(과도한 로그 방지하려면 throttle)
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(),
-                           5000, "read_data_rt(): unsupported key '%s'", key.c_str());
+      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 5000, "read_data_rt(): unsupported key '%s'", key.c_str());
       continue;
     }
 
     std_msgs::msg::Float32MultiArray msg;
-    msg.data = std::move(vals); // raw값 그대로
+    msg.data = std::move(vals); // using raw data
     it->second->publish(msg);
   }
 }
 
-// [modified]
-bool RobotController::extract_field(LPRT_OUTPUT_DATA_LIST temp,
-                                    const std::string& key,
-                                    std::vector<float>& out) {
-  // 필요한 필드만 우선 지원 (요청 확장 시 여기에 추가)
-  // 모든 항목은 raw float 배열 그대로 복사
-  auto copy_arr = [&](const float* src, size_t n) {
-    out.assign(src, src + n);
-    return true;
-  };
+// [modified] : Extracts a specific field from the real-time data structure (LPRT_OUTPUT_DATA_LIST)
+bool RobotController::extract_field(LPRT_OUTPUT_DATA_LIST temp, const std::string& key, std::vector<float>& out)
+{
+    out.clear();
 
-  if (key == "actual_joint_position")        return copy_arr(temp->actual_joint_position,        6);
-  if (key == "actual_joint_position_abs")    return copy_arr(temp->actual_joint_position_abs,    6);
-  if (key == "actual_joint_velocity")        return copy_arr(temp->actual_joint_velocity,        6);
-  if (key == "actual_joint_velocity_abs")    return copy_arr(temp->actual_joint_velocity_abs,    6);
-  if (key == "actual_tcp_position")          return copy_arr(temp->actual_tcp_position,          6);
-  if (key == "actual_tcp_velocity")          return copy_arr(temp->actual_tcp_velocity,          6);
-  if (key == "actual_flange_position")       return copy_arr(temp->actual_flange_position,       6);
-  if (key == "actual_flange_velocity")       return copy_arr(temp->actual_flange_velocity,       6);
-  if (key == "actual_motor_torque")          return copy_arr(temp->actual_motor_torque,          6);
-  if (key == "actual_joint_torque")          return copy_arr(temp->actual_joint_torque,          6);
-  if (key == "raw_joint_torque")             return copy_arr(temp->raw_joint_torque,             6);
-  if (key == "raw_force_torque")             return copy_arr(temp->raw_force_torque,             6);
-  if (key == "external_joint_torque")        return copy_arr(temp->external_joint_torque,        6);
-  if (key == "external_tcp_force")           return copy_arr(temp->external_tcp_force,           6);
-  if (key == "target_joint_position")        return copy_arr(temp->target_joint_position,        6);
-  if (key == "target_joint_velocity")        return copy_arr(temp->target_joint_velocity,        6);
-  if (key == "target_joint_acceleration")    return copy_arr(temp->target_joint_acceleration,    6);
-  if (key == "target_motor_torque")          return copy_arr(temp->target_motor_torque,          6);
-  if (key == "target_tcp_position")          return copy_arr(temp->target_tcp_position,          6);
-  if (key == "target_tcp_velocity")          return copy_arr(temp->target_tcp_velocity,          6);
-  if (key == "gravity_torque")               return copy_arr(temp->gravity_torque,               6);
-  if (key == "joint_temperature")            return copy_arr(temp->joint_temperature,            6);
-  if (key == "goal_joint_position")          return copy_arr(temp->goal_joint_position,          6);
-  if (key == "goal_tcp_position")            return copy_arr(temp->goal_tcp_position,            6);
+    // Helper lambdas for copying arrays and scalars of various data types
+    auto copy_arr_f = [&](const float* src, size_t n) {
+        out.assign(src, src + n);
+        return true;
+    };
+    auto copy_arr_d = [&](const double* src, size_t n) {
+        out.resize(n);
+        for (size_t i = 0; i < n; ++i)
+            out[i] = static_cast<float>(src[i]);
+        return true;
+    };
+    auto copy_arr_i32 = [&](const int32_t* src, size_t n) {
+        out.resize(n);
+        for (size_t i = 0; i < n; ++i)
+            out[i] = static_cast<float>(src[i]);
+        return true;
+    };
+    auto copy_arr_u32 = [&](const uint32_t* src, size_t n) {
+        out.resize(n);
+        for (size_t i = 0; i < n; ++i)
+            out[i] = static_cast<float>(src[i]);
+        return true;
+    };
+    auto copy_arr_u8 = [&](const unsigned char* src, size_t n) {
+        out.resize(n);
+        for (size_t i = 0; i < n; ++i)
+            out[i] = static_cast<float>(src[i]);
+        return true;
+    };
 
-  // 필요 시 단일/기타 필드(예: time_stamp)는 별도 토픽으로 Float64 등으로 확장 가능
-  return false;
+    auto copy_scalar_d = [&](double v) {
+        out = { static_cast<float>(v) };
+        return true;
+    };
+    auto copy_scalar_i32 = [&](int32_t v) {
+        out = { static_cast<float>(v) };
+        return true;
+    };
+    auto copy_scalar_u32 = [&](uint32_t v) {
+        out = { static_cast<float>(v) };
+        return true;
+    };
+
+    auto copy_mat6x6_f = [&](const float m[6][6]) {
+        out.resize(36);
+        size_t k = 0;
+        for (int i = 0; i < 6; ++i)
+            for (int j = 0; j < 6; ++j)
+                out[k++] = m[i][j];
+        return true;
+    };
+    auto copy_mat6x6_d = [&](const double m[6][6]) {
+        out.resize(36);
+        size_t k = 0;
+        for (int i = 0; i < 6; ++i)
+            for (int j = 0; j < 6; ++j)
+                out[k++] = static_cast<float>(m[i][j]);
+        return true;
+    };
+
+    // 6-element float array fields ---
+    if (key == "actual_joint_position")        return copy_arr_f(temp->actual_joint_position, 6);
+    if (key == "actual_joint_position_abs")    return copy_arr_f(temp->actual_joint_position_abs, 6);
+    if (key == "actual_joint_velocity")        return copy_arr_f(temp->actual_joint_velocity, 6);
+    if (key == "actual_joint_velocity_abs")    return copy_arr_f(temp->actual_joint_velocity_abs, 6);
+    if (key == "actual_tcp_position")          return copy_arr_f(temp->actual_tcp_position, 6);
+    if (key == "actual_tcp_velocity")          return copy_arr_f(temp->actual_tcp_velocity, 6);
+    if (key == "actual_flange_position")       return copy_arr_f(temp->actual_flange_position, 6);
+    if (key == "actual_flange_velocity")       return copy_arr_f(temp->actual_flange_velocity, 6);
+    if (key == "actual_motor_torque")          return copy_arr_f(temp->actual_motor_torque, 6);
+    if (key == "actual_joint_torque")          return copy_arr_f(temp->actual_joint_torque, 6);
+    if (key == "raw_joint_torque")             return copy_arr_f(temp->raw_joint_torque, 6);
+    if (key == "raw_force_torque")             return copy_arr_f(temp->raw_force_torque, 6);
+    if (key == "external_joint_torque")        return copy_arr_f(temp->external_joint_torque, 6);
+    if (key == "external_tcp_force")           return copy_arr_f(temp->external_tcp_force, 6);
+    if (key == "target_joint_position")        return copy_arr_f(temp->target_joint_position, 6);
+    if (key == "target_joint_velocity")        return copy_arr_f(temp->target_joint_velocity, 6);
+    if (key == "target_joint_acceleration")    return copy_arr_f(temp->target_joint_acceleration, 6);
+    if (key == "target_motor_torque")          return copy_arr_f(temp->target_motor_torque, 6);
+    if (key == "target_tcp_position")          return copy_arr_f(temp->target_tcp_position, 6);
+    if (key == "target_tcp_velocity")          return copy_arr_f(temp->target_tcp_velocity, 6);
+    if (key == "gravity_torque")               return copy_arr_f(temp->gravity_torque, 6);
+    if (key == "joint_temperature")            return copy_arr_f(temp->joint_temperature, 6);
+    if (key == "goal_joint_position")          return copy_arr_f(temp->goal_joint_position, 6);
+    if (key == "goal_tcp_position")            return copy_arr_f(temp->goal_tcp_position, 6);
+
+    // 6x6 matrix fields
+    if (key == "coriolis_matrix")  return copy_mat6x6_f(temp->coriolis_matrix);
+    if (key == "mass_matrix")      return copy_mat6x6_f(temp->mass_matrix);
+    if (key == "jacobian_matrix")  return copy_mat6x6_f(temp->jacobian_matrix);
+
+    // 2-element fields (controller and encoder info)
+    if (key == "controller_analog_input_type")   return copy_arr_u8(temp->controller_analog_input_type,   2);
+    if (key == "controller_analog_input")        return copy_arr_f (temp->controller_analog_input,        2);
+    if (key == "controller_analog_output_type")  return copy_arr_u8(temp->controller_analog_output_type,  2);
+    if (key == "controller_analog_output")       return copy_arr_f (temp->controller_analog_output,       2);
+    if (key == "external_encoder_strobe_count")  return copy_arr_u8(temp->external_encoder_strobe_count,  2);
+    if (key == "external_encoder_count")         return copy_arr_u32(temp->external_encoder_count,        2);
+
+    // 4-element fields (flange analog input)
+    if (key == "flange_analog_input")            return copy_arr_f (temp->flange_analog_input, 4);
+
+    // Single scalar values
+    if (key == "time_stamp")               return copy_scalar_d  (temp->time_stamp);
+    if (key == "solution_space")           return copy_scalar_i32(temp->solution_space);
+    if (key == "singularity")              return copy_scalar_i32(temp->singularity);
+    if (key == "operation_speed_rate")     return copy_scalar_d  (temp->operation_speed_rate);
+    if (key == "controller_digital_input") return copy_scalar_u32(temp->controller_digital_input);
+    if (key == "controller_digital_output")return copy_scalar_u32(temp->controller_digital_output);
+    if (key == "flange_digital_input")     return copy_scalar_u32(temp->flange_digital_input);
+    if (key == "flange_digital_output")    return copy_scalar_u32(temp->flange_digital_output);
+    if (key == "robot_mode")               return copy_scalar_i32(temp->robot_mode);
+    if (key == "robot_state")              return copy_scalar_i32(temp->robot_state);
+    if (key == "control_mode")             return copy_scalar_i32(temp->control_mode);
+
+    return false;
 }
-
-
 
 void check_dsr_model(std::array<float, NUM_JOINT>& target_joint){
     if (m_model == "p3020"){


### PR DESCRIPTION
**Summary**

This PR adds a new feature that publishes selected real-time (RT) data from the Doosan controller as ROS2 topics.
It utilizes the read_data_rt() interface and converts its output into Float32MultiArray messages for monitoring robot states in real-time.

**Key Changes**

Added parameters:
use_rt_topic_pub, rt_topic_keys, rt_timer_ms

Added members for RT topic management (rt_pub_map_, rt_timer_, etc.)

Implemented publish_read_data_rt_selected() to periodically read and publish RT data

Implemented extract_field() to convert DRCF RT data into float arrays

**Result**

Each selected field from rt_topic_keys is published under /rt_topic/<field_name> at a configurable rate.
This allows real-time visualization or logging of joint, torque, and TCP force data during simulation or hardware operation.