### PR TITLE
fix : hot-fixed rt disconnection

### DIFF
--- a/dsr_controller2/src/dsr_controller2.cpp
+++ b/dsr_controller2/src/dsr_controller2.cpp
@@ -2856,7 +2856,8 @@ void OnLogAlarm(LPLOG_ALARM pLogAlarm)
 void OnDisConnected(){
 	RCLCPP_ERROR(rclcpp::get_logger("dsr_controller2"),"Disconnected.. Please check out Ethernet Cable.. ");
 	Drfl->stop_rt_control();
-    Drfl->disconnect_rt_control();
+    // To-do : Update disconnection function in controller version v3.6
+    // Drfl->disconnect_rt_control();
 	Drfl->close_connection(); // clean-up
 
 	

--- a/dsr_hardware2/src/dsr_hw_interface2.cpp
+++ b/dsr_hardware2/src/dsr_hw_interface2.cpp
@@ -411,7 +411,8 @@ return_type DRHWInterface::write(const rclcpp::Time &, const rclcpp::Duration &d
 DRHWInterface::~DRHWInterface()
 {
 	Drfl.stop_rt_control();
-	Drfl.disconnect_rt_control();
+	// To-do : Update disconnection function in controller version v3.6
+	// Drfl.disconnect_rt_control();
 	Drfl.close_connection();
 
 	RCLCPP_INFO(rclcpp::get_logger("dsr_hw_interface2"),"_______________________________________________\n"); 


### PR DESCRIPTION
hot-fixed rt disconnection

Problem : when disconnecting rt socket, TP popped up server error 
Note:
  - Currently, the disconnect_rt function has been temporarily disabled by commenting it out in the destructor of hw interface.
  - Once the controller version is updated, the disconnect functionality will be properly restored and re-enabled.
  - Even without explicitly calling the disconnect function, the system automatically disconnects within 5 seconds.
  - A warning pop-up may appear on the TP due to this behavior, but it does not affect any RT functionality.
