### PR TITLE
Fix: add missing update_rate to p3020 xarco

### DIFF
--- a/dsr_description2/ros2_control/p3020.gz_ros2_control.xacro
+++ b/dsr_description2/ros2_control/p3020.gz_ros2_control.xacro
@@ -14,7 +14,7 @@
   gripper:=none
   mobile:=none
   use_gazebo:=false
-  update_rate
+  update_rate:=100
   ">
 
     <ros2_control name="${model}" type="system">

--- a/dsr_description2/ros2_control/p3020.ros2_control.xacro
+++ b/dsr_description2/ros2_control/p3020.ros2_control.xacro
@@ -8,7 +8,7 @@
   port:=12345
   mode:=real
   model:=p3020
-  update_rate
+  update_rate:=100
   ">
 
     <ros2_control name="${name}" type="system">

--- a/dsr_description2/xacro/p3020.urdf.xacro
+++ b/dsr_description2/xacro/p3020.urdf.xacro
@@ -11,6 +11,7 @@
   <xacro:arg name="rt_host" default=""/>
   <xacro:arg name="mode" default=""/>
   <xacro:arg name="model" default=""/>
+  <xacro:arg name="update_rate" default=""/>
 
   <xacro:property name="cr" value="$(arg color)"/>
   <xacro:property name="gr" value="$(arg gripper)"/>
@@ -21,6 +22,7 @@
   <xacro:property name="port" value="$(arg port)"/>
   <xacro:property name="mode" value="$(arg mode)"/>
   <xacro:property name="model" value="$(arg model)"/>
+  <xacro:property name="update_rate" value="$(arg update_rate)"/>
 
   <xacro:if value="${cr == 'white'}">
      <xacro:include filename="$(find dsr_description2)/xacro/macro.p3020.white.xacro" />
@@ -58,6 +60,7 @@
         port="${port}"
         mode="${mode}"
         model="${model}"
+        update_rate="${update_rate}"
       />
     </xacro:unless>
   </xacro:unless>


### PR DESCRIPTION
This PR might not be perfect, but is trying to address the missing `update_rate` for p3020