### PR TITLE
fix: Moveit Launch

### DIFF
--- a/dsr_moveit2/dsr_moveit_config_a0509/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_a0509/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_a0912/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_a0912/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_e0509/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_e0509/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_h2017/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_h2017/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_h2515/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_h2515/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_m0609/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_m0609/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_m0617/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_m0617/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_m1013/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_m1013/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"
@@ -122,8 +123,6 @@ def rviz_and_move_group_fn(context):
         executable="move_group",
         namespace=ns_value,
         output="screen",
-        #        # parameters=common_params,
-        parameters=move_group_params,
         parameters=move_group_params,
     )
 
@@ -155,8 +154,6 @@ def rviz_and_move_group_fn(context):
         name="rviz2_moveit",
         output="log",
         arguments=["-d", rviz_full_config],
-        #        # parameters=common_params,
-        parameters=rviz_params,
         parameters=rviz_params,
     )
 

--- a/dsr_moveit2/dsr_moveit_config_m1509/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_m1509/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"

--- a/dsr_moveit2/dsr_moveit_config_p3020/launch/start.launch.py
+++ b/dsr_moveit2/dsr_moveit_config_p3020/launch/start.launch.py
@@ -84,6 +84,7 @@ def generate_robot_description_action(context, *args, **kwargs):
 
 def rviz_and_move_group_fn(context):
     model_value = LaunchConfiguration('model').perform(context)
+    ns_value = LaunchConfiguration('name').perform(context)
     gui = LaunchConfiguration('gui').perform(context).lower() == 'true'
 
     package_name = f"dsr_moveit_config_{model_value}"


### PR DESCRIPTION
## Summary of Changes
Fix MoveIt2 launch files by defining `ns_value` and removing duplicated `parameters` entries.

## Related JIRA Issue
N/A

## Description
This PR includes:
- Define `ns_value` in `rviz_and_move_group_fn` across MoveIt2 model launch files
- Remove duplicated `parameters` entries in MoveGroup/RViz node definitions

## Key Changes
- Added `ns_value = LaunchConfiguration('name').perform(context)` to MoveIt2 `start.launch.py`
- Cleaned up duplicate `parameters` in MoveGroup and RViz nodes
- Applied to all MoveIt2 model launch configs under `dsr_moveit2/dsr_moveit_config_*/launch/start.launch.py`
