### PR TITLE
fix include path

### DIFF
--- a/dsr_example2/dsr_realtime_control/include/dsr_realtime_control/realtime_control.hpp
+++ b/dsr_example2/dsr_realtime_control/include/dsr_realtime_control/realtime_control.hpp
@@ -34,7 +34,7 @@
 #include <atomic>
 #include <mutex>
 
-#include "../../dsr_common2/include/DRFLEx.h"
+#include "../../../dsr_common2/include/DRFLEx.h"
 
 typedef struct {
     /* timestamp at the data of data acquisition */


### PR DESCRIPTION
The relative path that is attempted to include in `realtime_control.hpp` is wrong (at least in the `jazzy` branch). This PR fixes that.